### PR TITLE
Add logging import to utils

### DIFF
--- a/reggie/ingestion/utils.py
+++ b/reggie/ingestion/utils.py
@@ -1,6 +1,7 @@
 import boto3
 import json
 import re
+import logging
 
 from dateutil import parser
 from botocore.exceptions import ClientError
@@ -14,6 +15,7 @@ s3 = boto3.resource("s3")
 
 
 class MissingElectionCodesError(Exception):
+    pass
     pass
 
 

--- a/reggie/ingestion/utils.py
+++ b/reggie/ingestion/utils.py
@@ -16,7 +16,6 @@ s3 = boto3.resource("s3")
 
 class MissingElectionCodesError(Exception):
     pass
-    pass
 
 
 class TooManyMalformedLines(Exception):


### PR DESCRIPTION
This simply imports logging in the utils.py file so that the get_metadata_for_key function doesn't break on the exception.