### PR TITLE
Updated example CLI invocation in README to use --file_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ nc_dataframe, metadata = convert_voter_file(state='north_carolina',
 ```
 ### Command Line
 ```bash
-$ reg --state north_carolina --local_file nc_2018-12-22.zip --date 2018-12-22
+$ reg --state north_carolina --local_file nc_2018-12-22.zip --file_date 2018-12-22
 
 ```
 


### PR DESCRIPTION
It looks like `--date` has been deprecated some time back. I had to dig through
the source code to figure out why it wasn't working.