### PR TITLE
Cleaning extra spaces during data ingestion

### DIFF
--- a/reggie/configs/configs.py
+++ b/reggie/configs/configs.py
@@ -212,6 +212,7 @@ class Config(object):
             and (field not in exclude):
                 string_copy = df[field].astype(str)
                 stripped_copy = string_copy.str.strip()
+                stripped_copy = stripped_copy.str.split().str.join(" ")
                 lower_copy = stripped_copy.str.lower()
                 utf_decoded = lower_copy.str.encode('utf-8', errors='ignore')
                 df[field] = utf_decoded.str.decode('utf-8')


### PR DESCRIPTION
Instead of just: `stripped_copy = string_copy.str.strip()`

Have:
`stripped_copy = string_copy.str.strip()`
`stripped_copy = stripped_copy.str.split().str.join(" ")`

During the `coerce_strings` process in reggie. 

* Any unintended consequences?
* Best practices for cleaning extra spaces? (is the first line necessary with the second)?
* How to best notify/prepare analyst team for potential weird flags in the next few snapshots 