### PR TITLE
Remove SyntaxWarning informational message

### DIFF
--- a/reggie/ingestion/download.py
+++ b/reggie/ingestion/download.py
@@ -325,7 +325,7 @@ class Loader(object):
 
         new_files = None
         inferred_compression = self.infer_compression(s3_file_obj["name"])
-        if (compression_type == "infer"):
+        if compression_type == "infer":
             if inferred_compression is not None:
                 compression_type = inferred_compression
             else:

--- a/reggie/ingestion/download.py
+++ b/reggie/ingestion/download.py
@@ -325,7 +325,7 @@ class Loader(object):
 
         new_files = None
         inferred_compression = self.infer_compression(s3_file_obj["name"])
-        if compression_type is "infer":
+        if (compression_type == "infer"):
             if inferred_compression is not None:
                 compression_type = inferred_compression
             else:


### PR DESCRIPTION
Hey Team!
This is an extremely low priority PR that removes the informational message I get when running the Voteshield app. Essentially, whenever it is executed I see the following in the logs:

`analysis/locale_date_matrix.py:38: SyntaxWarning: "is" with a literal. Did you mean "=="?`

And I'm making my way around to remove all instances of these just for house keeping's sake.