### PR TITLE
remove middle name from match fields

### DIFF
--- a/reggie/configs/data/arizona.yaml
+++ b/reggie/configs/data/arizona.yaml
@@ -52,7 +52,6 @@ date_format: '%Y'
 party_identifier: desc_party
 match_fields:
   - text_name_first
-  - text_name_middle
   - text_name_last
   - year_of_birth
 name_fields:

--- a/reggie/configs/data/arizona2.yaml
+++ b/reggie/configs/data/arizona2.yaml
@@ -53,7 +53,6 @@ format:
 match_fields:
   - LastName
   - FirstName
-  - MiddleName
   - DOB
 name_fields:
   - LastName

--- a/reggie/configs/data/colorado.yaml
+++ b/reggie/configs/data/colorado.yaml
@@ -37,7 +37,6 @@ format:
   columnar_elections: false
 match_fields:
   - FIRST_NAME
-  - MIDDLE_NAME
   - LAST_NAME
   - BIRTH_YEAR
 name_fields:

--- a/reggie/configs/data/florida.yaml
+++ b/reggie/configs/data/florida.yaml
@@ -42,7 +42,6 @@ format:
   columnar_elections: false
 match_fields:
   - Name_First
-  - Name_Middle
   - Name_Last
   - Birth_Date
 name_fields:

--- a/reggie/configs/data/georgia.yaml
+++ b/reggie/configs/data/georgia.yaml
@@ -27,7 +27,6 @@ generated_columns:
   sparse_history: int[]
 match_fields:
   - First_name
-  - Middle_maiden_name
   - Last_name
   - Year_of_Birth
 name_fields:

--- a/reggie/configs/data/iowa.yaml
+++ b/reggie/configs/data/iowa.yaml
@@ -32,7 +32,6 @@ ordered_generated_columns:
   - sparse_history
 match_fields:
   - FIRST_NAME
-  - MIDDLE_NAME
   - LAST_NAME
   - BIRTHDATE
 name_fields:

--- a/reggie/configs/data/kansas.yaml
+++ b/reggie/configs/data/kansas.yaml
@@ -21,7 +21,6 @@ party_identifier: desc_party
 has_headers: YES
 match_fields:
   - text_name_first
-  - text_name_middle
   - text_name_last
   - date_of_birth
 name_fields:

--- a/reggie/configs/data/michigan.yaml
+++ b/reggie/configs/data/michigan.yaml
@@ -26,7 +26,6 @@ missing_required_fields: true
 reason_code: cancellation_reason
 match_fields:
   - FIRST_NAME
-  - MIDDLE_NAME
   - LAST_NAME
   - YEAR_OF_BIRTH
 date_format:

--- a/reggie/configs/data/minnesota.yaml
+++ b/reggie/configs/data/minnesota.yaml
@@ -24,7 +24,6 @@ date_format:
   - '%Y-%m-%d hh:mm:ss'
 match_fields:
   - FirstName
-  - MiddleName
   - LastName
   - DOBYear
 name_fields:

--- a/reggie/configs/data/missouri.yaml
+++ b/reggie/configs/data/missouri.yaml
@@ -21,7 +21,6 @@ no_party_affiliation: npa
 missing_required_fields: true
 match_fields:
   - First Name
-  - Middle Name
   - Last Name
   - Birthdate
 name_fields:

--- a/reggie/configs/data/nevada.yaml
+++ b/reggie/configs/data/nevada.yaml
@@ -31,7 +31,6 @@ date_format: '%m/%d/%Y'
 party_identifier: Party
 match_fields:
   - First_Name
-  - Middle_Name
   - Last_Name
   - Birth_Date
 name_fields:

--- a/reggie/configs/data/new_jersey.yaml
+++ b/reggie/configs/data/new_jersey.yaml
@@ -31,7 +31,6 @@ conservative_party: CNV
 socialist_party: SSP
 match_fields:
   - first_name
-  - middle_name
   - last_name
   - dob
 name_fields:

--- a/reggie/configs/data/new_jersey2.yaml
+++ b/reggie/configs/data/new_jersey2.yaml
@@ -33,7 +33,6 @@ valid_voting_methods: ['Machine', 'Mail In', 'Provisional', 'Emergency']
 match_fields:
   - last
   - first
-  - middle
   - dob
 name_fields:
   - last

--- a/reggie/configs/data/new_york.yaml
+++ b/reggie/configs/data/new_york.yaml
@@ -36,7 +36,6 @@ party_identifier: enrollment
 gender_identifier: gender
 match_fields:
   - firstname
-  - middlename
   - lastname
   - dob
 name_fields:

--- a/reggie/configs/data/north_carolina.yaml
+++ b/reggie/configs/data/north_carolina.yaml
@@ -28,7 +28,6 @@ date_format: '%Y'
 party_identifier: party_cd
 match_fields:
   - first_name
-  - midl_name
   - last_name
   - birth_year
 name_fields:

--- a/reggie/configs/data/ohio.yaml
+++ b/reggie/configs/data/ohio.yaml
@@ -20,7 +20,6 @@ date_format: '%Y-%m-%d'
 party_identifier: PARTY_AFFILIATION
 match_fields:
   - FIRST_NAME
-  - MIDDLE_NAME
   - LAST_NAME
   - DATE_OF_BIRTH
 name_fields:

--- a/reggie/configs/data/pennsylvania.yaml
+++ b/reggie/configs/data/pennsylvania.yaml
@@ -25,7 +25,6 @@ date_format: '%m/%d/%Y'
 has_headers: False
 match_fields:
   - first_name
-  - middle_name
   - surname
   - dob
 name_fields:

--- a/reggie/configs/data/texas.yaml
+++ b/reggie/configs/data/texas.yaml
@@ -36,7 +36,6 @@ featureless_date_cols:
   - election_date
 match_fields:
   - First_Name
-  - Middle_Name
   - Last_Name
   - Date_of_Birth
 name_fields:

--- a/reggie/configs/data/virginia.yaml
+++ b/reggie/configs/data/virginia.yaml
@@ -50,7 +50,6 @@ hist_columns:
   - PROVISIONAL
 match_fields:
   - FIRST_NAME
-  - MIDDLE_NAME
   - LAST_NAME
   - DOB
 name_fields:


### PR DESCRIPTION
I talked with Omeed about how the analysts are going forward with matching removed / registered voters only on [first name, last name, & DOB] because that seems most effective.

To support this, I have removed middle name from the match fields used to match voters during the snapshot diff.