### PR TITLE
fix new georgia history files to work with file check

### DIFF
--- a/reggie/ingestion/download.py
+++ b/reggie/ingestion/download.py
@@ -936,7 +936,6 @@ class Preprocessor(Loader):
         voter_files = []
         vh_files = []
         for i in new_files:
-            logging.info("this file = {}".format(i["name"]))
             if "Georgia_Daily_VoterBase.txt".lower() in i["name"].lower():
                 logging.info("Detected voter file: " + i["name"])
                 voter_files.append(i)

--- a/reggie/ingestion/download.py
+++ b/reggie/ingestion/download.py
@@ -932,27 +932,34 @@ class Preprocessor(Loader):
         logging.info("GEORGIA: loading voter and voter history file")
         new_files = self.unpack_files(
             compression='unzip', file_obj=self.main_file)
+
+        voter_files = []
         vh_files = []
-
-        if not self.ignore_checks:
-            self.file_check(len(new_files))
-
         for i in new_files:
+            logging.info("this file = {}".format(i["name"]))
             if "Georgia_Daily_VoterBase.txt".lower() in i["name"].lower():
                 logging.info("Detected voter file: " + i["name"])
-                df_voters = self.read_csv_count_error_lines(
-                    i["obj"], sep="|", quotechar='"', quoting=3,
-                    error_bad_lines=False)
-                try:
-                    df_voters.columns = self.config["ordered_columns"]
-                except ValueError:
-                    logging.info("Incorrect number of columns found for Georgia")
-                    raise MissingNumColumnsError("{} state is missing columns".format(self.state), self.state,
-                                                 len(self.config["ordered_columns"]), len(df_voters.columns))
-                df_voters['Registration_Number'] = df_voters[
-                    'Registration_Number'].astype(str).str.zfill(8)
-            elif "TXT" in i["name"]:
+                voter_files.append(i)
+            elif "txt" in i["name"].lower():
                 vh_files.append(i)
+        logging.info("Detected {} history files".format(len(vh_files)))
+
+        if not self.ignore_checks:
+            self.file_check(len(voter_files))
+
+        df_voters = self.read_csv_count_error_lines(
+            voter_files[0]["obj"], sep="|", quotechar='"', quoting=3,
+            error_bad_lines=False)
+        try:
+            df_voters.columns = self.config["ordered_columns"]
+        except ValueError:
+            logging.info("Incorrect number of columns found for Georgia")
+            raise MissingNumColumnsError("{} state is missing columns".format(
+                self.state), self.state, len(self.config["ordered_columns"]),
+                len(df_voters.columns))
+        df_voters['Registration_Number'] = df_voters[
+            'Registration_Number'].astype(str).str.zfill(8)
+
         concat_history_file = concat_and_delete(vh_files)
 
         logging.info("Performing GA history manipulation")


### PR DESCRIPTION
Georgia used to have history files, then it didn't for a long time. Now it does again! I changed the logic a little, to allow us to use the new file check to just check that there is a single voter file in the package. (There's no set number of history files that we should have, so there's no way to check for that.)