### PR TITLE
Add tags directory to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ experiments
 .idea
 build
 dist
-
+tags


### PR DESCRIPTION
### What this does
Adds the `tags` directory to the `.gitignore` file for vim's `ctags` feature. 