### PR TITLE
add precinct identifier in Michigan

### DIFF
--- a/reggie/configs/data/michigan.yaml
+++ b/reggie/configs/data/michigan.yaml
@@ -9,6 +9,7 @@ jurisdiction_identifier: JURISDICTION_CODE
 primary_locale_identifier: JURISDICTION_CODE
 numeric_primary_locale: true
 primary_locale_type: jurisdiction
+precinct_identifier: PRECINCT
 birthday_identifier: YEAR_OF_BIRTH
 early_voter_identifier: IS_PERMANENT_ABSENTEE_VOTER
 voter_status: VOTER_STATUS_TYPE_CODE


### PR DESCRIPTION
Belated BallotShield addition: now that I'm moving voters table data queries over to RedShift, I will actually be able to use the real file data in Michigan (precinct data for Michigan in our voters table was all messed up, so I couldn't use it at all).