### PR TITLE
Bugfix/nc preprocessor

### DIFF
--- a/reggie/ingestion/preprocessor/alaska_preprocessor.py
+++ b/reggie/ingestion/preprocessor/alaska_preprocessor.py
@@ -113,6 +113,6 @@ class PreprocessAlaska(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/alaska_preprocessor.py
+++ b/reggie/ingestion/preprocessor/alaska_preprocessor.py
@@ -113,6 +113,6 @@ class PreprocessAlaska(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/arizona2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/arizona2_preprocessor.py
@@ -87,7 +87,6 @@ class PreprocessArizona2(Preprocessor):
                 "VRAZVoterID",
             ],
         )
-        raise ValueError("Arbitrary AF")
         voter_columns = [c for c in main_df.columns if not c[0].isdigit()]
         history_columns = [c for c in main_df.columns if c[0].isdigit()]
 

--- a/reggie/ingestion/preprocessor/arizona2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/arizona2_preprocessor.py
@@ -87,7 +87,7 @@ class PreprocessArizona2(Preprocessor):
                 "VRAZVoterID",
             ],
         )
-
+        raise ValueError("Arbitrary AF")
         voter_columns = [c for c in main_df.columns if not c[0].isdigit()]
         history_columns = [c for c in main_df.columns if c[0].isdigit()]
 

--- a/reggie/ingestion/preprocessor/arkansas_preprocessor.py
+++ b/reggie/ingestion/preprocessor/arkansas_preprocessor.py
@@ -117,6 +117,6 @@ class PreprocessArkansas(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/arkansas_preprocessor.py
+++ b/reggie/ingestion/preprocessor/arkansas_preprocessor.py
@@ -117,6 +117,6 @@ class PreprocessArkansas(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/colorado_preprocessor.py
+++ b/reggie/ingestion/preprocessor/colorado_preprocessor.py
@@ -208,6 +208,6 @@ class PreprocessColorado(Preprocessor):
         logging.info("Colorado: writing out")
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8")),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/connecticut_preprocessor.py
+++ b/reggie/ingestion/preprocessor/connecticut_preprocessor.py
@@ -159,6 +159,6 @@ class PreprocessConnecticut(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/connecticut_preprocessor.py
+++ b/reggie/ingestion/preprocessor/connecticut_preprocessor.py
@@ -159,6 +159,6 @@ class PreprocessConnecticut(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/dc_preprocessor.py
+++ b/reggie/ingestion/preprocessor/dc_preprocessor.py
@@ -120,6 +120,6 @@ class PreprocessDC(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/dc_preprocessor.py
+++ b/reggie/ingestion/preprocessor/dc_preprocessor.py
@@ -120,6 +120,6 @@ class PreprocessDC(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/delaware_preprocessor.py
+++ b/reggie/ingestion/preprocessor/delaware_preprocessor.py
@@ -101,6 +101,6 @@ class PreprocessDelaware(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/delaware_preprocessor.py
+++ b/reggie/ingestion/preprocessor/delaware_preprocessor.py
@@ -101,6 +101,6 @@ class PreprocessDelaware(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/florida_preprocessor.py
+++ b/reggie/ingestion/preprocessor/florida_preprocessor.py
@@ -153,6 +153,6 @@ class PreprocessFlorida(Preprocessor):
         logging.info("FLORIDA: writing out")
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voters.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voters.to_csv(encoding="utf-8")),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/georgia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/georgia_preprocessor.py
@@ -27,7 +27,7 @@ class PreprocessGeorgia(Preprocessor):
             **kwargs
         )
         self.raw_s3_file = raw_s3_file
-        self.config = config_file
+        self.config_file = config_file
         self.processed_file = None
 
     def execute(self):
@@ -203,6 +203,6 @@ class PreprocessGeorgia(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voters.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voters.to_csv(encoding="utf-8")),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/maryland_preprocessor.py
+++ b/reggie/ingestion/preprocessor/maryland_preprocessor.py
@@ -128,6 +128,6 @@ class PreprocessMaryland(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/maryland_preprocessor.py
+++ b/reggie/ingestion/preprocessor/maryland_preprocessor.py
@@ -128,6 +128,6 @@ class PreprocessMaryland(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/minnesota_preprocessor.py
+++ b/reggie/ingestion/preprocessor/minnesota_preprocessor.py
@@ -123,7 +123,7 @@ class PreprocessMinnesota(Preprocessor):
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
             io_obj=StringIO(
-                voter_reg_df.to_csv(encoding="utf-8", index=False)
+                voter_reg_df.to_csv(encoding="utf-8")
             ),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/montana_preprocessor.py
+++ b/reggie/ingestion/preprocessor/montana_preprocessor.py
@@ -163,6 +163,6 @@ class PreprocessMontana(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/montana_preprocessor.py
+++ b/reggie/ingestion/preprocessor/montana_preprocessor.py
@@ -163,6 +163,6 @@ class PreprocessMontana(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/new_york_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_york_preprocessor.py
@@ -33,7 +33,7 @@ class PreprocessNewYork(Preprocessor):
         if self.raw_s3_file is not None:
             self.main_file = self.s3_download()
 
-        config = self.config_file
+        # config = self.config_file
         new_files = self.unpack_files(
             file_obj=self.main_file, compression="infer"
         )
@@ -49,7 +49,7 @@ class PreprocessNewYork(Preprocessor):
         main_df = self.read_csv_count_error_lines(
             self.main_file["obj"],
             header=None,
-            names=config["ordered_columns"],
+            names=self.config["ordered_columns"],
             encoding="latin-1",
             error_bad_lines=False,
         )

--- a/reggie/ingestion/preprocessor/new_york_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_york_preprocessor.py
@@ -33,7 +33,6 @@ class PreprocessNewYork(Preprocessor):
         if self.raw_s3_file is not None:
             self.main_file = self.s3_download()
 
-        # config = self.config_file
         new_files = self.unpack_files(
             file_obj=self.main_file, compression="infer"
         )

--- a/reggie/ingestion/preprocessor/north_carolina_preprocessor.py
+++ b/reggie/ingestion/preprocessor/north_carolina_preprocessor.py
@@ -4,6 +4,7 @@ from reggie.ingestion.download import (
     FileItem,
 )
 from reggie.ingestion.utils import MissingNumColumnsError
+from reggie.configs.configs import Config
 import logging
 import datetime
 from io import StringIO
@@ -26,7 +27,7 @@ class PreprocessNorthCarolina(Preprocessor):
         )
         self.raw_s3_file = raw_s3_file
         self.processed_file = None
-        self.config = config_file
+        self.config = Config(file_name=config_file)
 
     def execute(self):
         if self.raw_s3_file is not None:
@@ -136,6 +137,6 @@ class PreprocessNorthCarolina(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(voter_df.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(voter_df.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/north_carolina_preprocessor.py
+++ b/reggie/ingestion/preprocessor/north_carolina_preprocessor.py
@@ -26,6 +26,7 @@ class PreprocessNorthCarolina(Preprocessor):
         )
         self.raw_s3_file = raw_s3_file
         self.processed_file = None
+        self.config = config_file
 
     def execute(self):
         if self.raw_s3_file is not None:
@@ -38,7 +39,6 @@ class PreprocessNorthCarolina(Preprocessor):
         if not self.ignore_checks:
             self.file_check(len(new_files))
 
-        self.config = config_file
         for i in new_files:
             if ("ncvhis" in i["name"]) and (".txt" in i["name"]):
                 vote_hist_file = i

--- a/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
+++ b/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
@@ -108,6 +108,6 @@ class PreprocessOklahoma(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
+++ b/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
@@ -108,6 +108,6 @@ class PreprocessOklahoma(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/pennsylvania_preprocessor.py
+++ b/reggie/ingestion/preprocessor/pennsylvania_preprocessor.py
@@ -4,6 +4,7 @@ from reggie.ingestion.download import (
     FileItem,
 )
 from reggie.ingestion.utils import format_column_name
+from reggie.configs.configs import Config
 import logging
 import pandas as pd
 import datetime
@@ -25,12 +26,13 @@ class PreprocessPennsylvania(Preprocessor):
         )
         self.raw_s3_file = raw_s3_file
         self.processed_file = None
+        self.config_file = config_file
 
     def execute(self):
         if self.raw_s3_file is not None:
             self.main_file = self.s3_download()
 
-        config = config_file
+        config = Config(file_name=self.config_file)
         new_files = self.unpack_files(file_obj=self.main_file)
         voter_files = [f for f in new_files if "FVE" in f["name"]]
         election_maps = [f for f in new_files if "Election Map" in f["name"]]

--- a/reggie/ingestion/preprocessor/rhode_island_preprocessor.py
+++ b/reggie/ingestion/preprocessor/rhode_island_preprocessor.py
@@ -137,6 +137,6 @@ class PreprocessRhodeIsland(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/rhode_island_preprocessor.py
+++ b/reggie/ingestion/preprocessor/rhode_island_preprocessor.py
@@ -137,6 +137,6 @@ class PreprocessRhodeIsland(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/south_dakota_preprocessor.py
+++ b/reggie/ingestion/preprocessor/south_dakota_preprocessor.py
@@ -96,6 +96,6 @@ class PreprocessSouthDakota(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/south_dakota_preprocessor.py
+++ b/reggie/ingestion/preprocessor/south_dakota_preprocessor.py
@@ -96,6 +96,6 @@ class PreprocessSouthDakota(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/texas_preprocessor.py
+++ b/reggie/ingestion/preprocessor/texas_preprocessor.py
@@ -234,6 +234,6 @@ class PreprocessTexas(Preprocessor):
         logging.info("Texas: writing out")
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8")),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/vermont_preprocessor.py
+++ b/reggie/ingestion/preprocessor/vermont_preprocessor.py
@@ -96,6 +96,6 @@ class PreprocessVermont(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/vermont_preprocessor.py
+++ b/reggie/ingestion/preprocessor/vermont_preprocessor.py
@@ -96,6 +96,6 @@ class PreprocessVermont(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/washington_preprocessor.py
+++ b/reggie/ingestion/preprocessor/washington_preprocessor.py
@@ -132,6 +132,6 @@ class PreprocessWashington(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/washington_preprocessor.py
+++ b/reggie/ingestion/preprocessor/washington_preprocessor.py
@@ -132,6 +132,6 @@ class PreprocessWashington(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/west_virginia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/west_virginia_preprocessor.py
@@ -82,6 +82,6 @@ class PreprocessWestVirginia(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/west_virginia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/west_virginia_preprocessor.py
@@ -82,6 +82,6 @@ class PreprocessWestVirginia(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/wyoming_preprocessor.py
+++ b/reggie/ingestion/preprocessor/wyoming_preprocessor.py
@@ -184,6 +184,6 @@ class PreprocessWyoming(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
+            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=True)),
             s3_bucket=self.s3_bucket,
         )

--- a/reggie/ingestion/preprocessor/wyoming_preprocessor.py
+++ b/reggie/ingestion/preprocessor/wyoming_preprocessor.py
@@ -184,6 +184,6 @@ class PreprocessWyoming(Preprocessor):
 
         self.processed_file = FileItem(
             name="{}.processed".format(self.config["state"]),
-            io_obj=StringIO(df_voter.to_csv(encoding="utf-8", index=False)),
+            io_obj=StringIO(df_voter.to_csv(encoding="latin-1", index=True)),
             s3_bucket=self.s3_bucket,
         )


### PR DESCRIPTION
Fixes the NC and PA preprocessors as they incorrectly created a config item, then reverts the to_csv encoding and index values of many preprocessors to their previous/correct forms