### PR TITLE
Removed the space in the Zavala county ID

### DIFF
--- a/reggie/configs/primary_locale_names/texas.json
+++ b/reggie/configs/primary_locale_names/texas.json
@@ -252,5 +252,5 @@
   { "name": "Yoakum", "id": "251" },
   { "name": "Young", "id": "252" },
   { "name": "Zapata", "id": "253" },
-  { "name": "Zavala", "id": "254 " }
+  { "name": "Zavala", "id": "254" }
 ]


### PR DESCRIPTION
Removes the erroneous space in the Zavala County ID, which was causing some issues