### PR TITLE
Wisconsin multiple possible file formats

### DIFF
--- a/reggie/ingestion/download.py
+++ b/reggie/ingestion/download.py
@@ -521,14 +521,20 @@ class Preprocessor:
         sys.stderr.flush()
         original_stderr = sys.stderr
 
+        num_skipped = 0
+        df = None
         try:
             sys.stderr = ErrorLog()
             df = pd.read_csv(file_obj, **kwargs)
             num_skipped = sys.stderr.count_skipped_lines()
             sys.stderr.print_log_string()   # still print original warning output
             sys.stderr = original_stderr
+        except UnicodeDecodeError:
+            sys.stderr = original_stderr
+            raise
         except Exception as e:
-            logging.error(e)
+            logging.error("{}: {}".format(type(e), e))
+            sys.stderr = original_stderr
 
         if num_skipped > 0:
             logging.info(

--- a/reggie/ingestion/preprocessor/wisconsin_preprocessor.py
+++ b/reggie/ingestion/preprocessor/wisconsin_preprocessor.py
@@ -51,6 +51,7 @@ class PreprocessWisconsin(Preprocessor):
                 main_file["obj"], sep="\t", error_bad_lines=False
             )
         except UnicodeDecodeError:
+            main_file["obj"].seek(0)
             main_df = self.read_csv_count_error_lines(
                 main_file["obj"], sep=",", encoding="latin-1",
                 error_bad_lines=False

--- a/reggie/ingestion/preprocessor/wisconsin_preprocessor.py
+++ b/reggie/ingestion/preprocessor/wisconsin_preprocessor.py
@@ -45,9 +45,17 @@ class PreprocessWisconsin(Preprocessor):
         else:
             main_file = new_files[0]
 
-        main_df = self.read_csv_count_error_lines(
-            main_file["obj"], sep="\t", error_bad_lines=False
-        )
+        # Wisconsin comes in two slightly different formats
+        try:
+            main_df = self.read_csv_count_error_lines(
+                main_file["obj"], sep="\t", error_bad_lines=False
+            )
+        except UnicodeDecodeError:
+            main_df = self.read_csv_count_error_lines(
+                main_file["obj"], sep=",", encoding="latin-1",
+                error_bad_lines=False
+            )
+
         logging.info(
             "dataframe memory usage: {}".format(
                 main_df.memory_usage(deep=True).sum()


### PR DESCRIPTION
This PR fixes this bug: https://sentry.io/organizations/voteshield/issues/2279332879/?project=5552704

Wisconsin seems to switch between 2 possible file formats. This PR changes the custom read_csv method a little, so we can raise the relevant error and change how we read it in depending on the file format.
