### PR TITLE
bug left over from preprocessor refactor

### DIFF
--- a/reggie/ingestion/preprocessor/new_hampshire_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_hampshire_preprocessor.py
@@ -31,7 +31,6 @@ class PreprocessNewHampshire(Preprocessor):
         if self.raw_s3_file is not None:
             self.main_file = self.s3_download()
 
-        config = config_file
         new_files = self.unpack_files(
             file_obj=self.main_file, compression="unzip"
         )


### PR DESCRIPTION
Removes a line referencing a config_file var that doesn't actually exist anymore. Configs are actually referenced via self.config