### PR TITLE
Bugfix/nj2 registration dates

### DIFF
--- a/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
@@ -152,7 +152,9 @@ class PreprocessNewJersey2(Preprocessor):
         # column and deprecating the registration_date information in the
         # voter_history file
         if "reg_date" in voter_df.columns:
-            voter_df.rename({"reg_date": "registration_date"}, inplace=True)
+            voter_df.rename(
+                columns={"reg_date": "registration_date"}, inplace=True
+            )
         else:
             voter_df["registration_date"] = voter_groups[
                 "voter_registrationDate"

--- a/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
@@ -157,7 +157,7 @@ class PreprocessNewJersey2(Preprocessor):
             )
             # remove the UTC, does not fail if not utc
             voter_df["registration_date"] = pd.to_datetime(
-                voter_df.registration_date
+                voter_df.registration_date, errors='coerce'
             ).dt.tz_localize(None)
         else:
             voter_df["registration_date"] = voter_groups[

--- a/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
@@ -155,8 +155,10 @@ class PreprocessNewJersey2(Preprocessor):
             voter_df.rename(
                 columns={"reg_date": "registration_date"}, inplace=True
             )
-            # remove the UTC
-            voter_df['registration_date'] = pd.to_datetime(voter_df.registration_date).dt.tz_localize(None)
+            # remove the UTC, does not fail if not utc
+            voter_df["registration_date"] = pd.to_datetime(
+                voter_df.registration_date
+            ).dt.tz_localize(None)
         else:
             voter_df["registration_date"] = voter_groups[
                 "voter_registrationDate"

--- a/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
@@ -155,6 +155,7 @@ class PreprocessNewJersey2(Preprocessor):
             voter_df.rename(
                 columns={"reg_date": "registration_date"}, inplace=True
             )
+            # remove the UTC
             voter_df['registration_date'] = pd.to_datetime(voter_df.registration_date).dt.tz_localize(None)
         else:
             voter_df["registration_date"] = voter_groups[

--- a/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
@@ -157,7 +157,7 @@ class PreprocessNewJersey2(Preprocessor):
             )
             # remove the UTC, does not fail if not utc
             voter_df["registration_date"] = pd.to_datetime(
-                voter_df.registration_date, errors='coerce'
+                voter_df.registration_date, errors="coerce"
             ).dt.tz_localize(None)
         else:
             voter_df["registration_date"] = voter_groups[

--- a/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
@@ -155,6 +155,7 @@ class PreprocessNewJersey2(Preprocessor):
             voter_df.rename(
                 columns={"reg_date": "registration_date"}, inplace=True
             )
+            voter_df['registration_date'] = pd.to_datetime(voter_df.registration_date).dt.tz_localize(None)
         else:
             voter_df["registration_date"] = voter_groups[
                 "voter_registrationDate"

--- a/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_jersey2_preprocessor.py
@@ -147,9 +147,16 @@ class PreprocessNewJersey2(Preprocessor):
         voter_df["gender"] = voter_groups["voter_sex"].apply(
             lambda x: list(x)[-1]
         )
-        voter_df["registration_date"] = voter_groups[
-            "voter_registrationDate"
-        ].apply(lambda x: list(x)[-1])
+
+        # at some point in in late 2020-early 2021 NJ started adding a reg_date
+        # column and deprecating the registration_date information in the
+        # voter_history file
+        if "reg_date" in voter_df.columns:
+            voter_df.rename({"reg_date": "registration_date"}, inplace=True)
+        else:
+            voter_df["registration_date"] = voter_groups[
+                "voter_registrationDate"
+            ].apply(lambda x: list(x)[-1])
 
         self.column_check(list(voter_df.columns))
 


### PR DESCRIPTION
Fixes Voteshield/Inspector#865

At some point recently NJ added a registration date column to the voter file rather than attaching it to the history file like we were previously processing it as. I added a check for the new file column to rename it to the expected name and if it exists and keep the old(er) method for backwards compatibility.