### PR TITLE
Georgia has numeric locales

### DIFF
--- a/reggie/configs/data/georgia.yaml
+++ b/reggie/configs/data/georgia.yaml
@@ -8,7 +8,7 @@ expected_number_of_files: 1
 voter_id: Registration_Number
 county_identifier: County_code
 primary_locale_identifier: County_code
-numeric_primary_locale: false
+numeric_primary_locale: true
 precinct_identifier: County_precinct_id
 birthday_identifier: Year_of_Birth
 voter_status: Voter_status


### PR DESCRIPTION
This corrects bad info in the Georgia yaml: Georgia DOES have numeric primary locale data.