### PR TITLE
add openpyxl to reggie since it was removed from Inspector

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ bs4>=0.0.1
 click>=7.1.2
 detect_delimiter>=0.1.1
 numpy>=1.19.2
+openpyxl>=3.0.5
 pandas>=0.23.1
 pytest>=6.0.0
 PyYAML>=5.3.1

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
         "bs4>=0.0.1",
         "pytest>=6.0.0",
         "detect_delimiter>=0.1.1",
+        "openpyxl>=3.0.5",
     ],
     url="https://github.com/Voteshield/reggie",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
@zzolo - Sorry I missed that this was not actually installed in reggie.

The dependency removals resulted in this error: https://sentry.io/organizations/voteshield/issues/2405585588/?project=5552704&referrer=slack so I think installing openpyxl in reggie should fix this.
