### PR TITLE
Fix date coercion when there is whitespace in a date field

### DIFF
--- a/reggie/configs/configs.py
+++ b/reggie/configs/configs.py
@@ -137,6 +137,7 @@ class Config(object):
         date_fields = [x for x in date_fields if x in df.columns]
         for field in date_fields:
             df[field] = df[field].apply(str)
+            df[field] = df[field].str.strip()
             df[field] = df[field].map(catch_floats)
             if not isinstance(self.data["date_format"], list):
                 df[field] = pd.to_datetime(df[field],


### PR DESCRIPTION
**What this does:**
This should allow the 2019-07-16 Washington file to be processed correctly, so that "LastVoted" ends up properly formatted as a date, by removing whitespace.

**Relevant Issue:** https://sentry.io/organizations/voteshield/issues/2415971811/?project=5552704
