### PR TITLE
Fix status code processing

### DIFF
--- a/reggie/configs/data/washington.yaml
+++ b/reggie/configs/data/washington.yaml
@@ -155,6 +155,7 @@ columns:
 # AbsenteeType: text
   LastVoted: date
   StatusCode: text
+  StatusCodeOrig: text
   party_identifier: text
 
 ordered_columns:
@@ -192,6 +193,7 @@ ordered_columns:
   - Registrationdate
   - LastVoted
   - StatusCode
+  - StatusCodeOrig
   - party_identifier
 
 column_classes (districts and precincts files):
@@ -276,6 +278,20 @@ status_codes:
   cancelled_felon: CF
   cancelled_deceased: CS
   cancelled_transferred: CT
+
+status_codes_remap:
+  A: A
+  Active: A
+  A-DUP: A
+  P: A
+  Pending: A
+  PDETH: A
+  PDUPL: A
+  PFELN: A
+  I: I
+  Inactive: I
+  I-DUP: I
+  IM-DUP: I
 
 gender_codes:
   Male: M

--- a/reggie/ingestion/preprocessor/washington_preprocessor.py
+++ b/reggie/ingestion/preprocessor/washington_preprocessor.py
@@ -166,6 +166,18 @@ class PreprocessWashington(Preprocessor):
         # since WA doesn't have party info
         df_voter.loc[:, self.config["party_identifier"]] = NO_PARTY_PLACEHOLDER
 
+        # Need to remap status codes because the original data are messy
+        df_voter["StatusCodeOrig"] = df_voter["StatusCode"]
+        df_voter["StatusCode"] = df_voter["StatusCodeOrig"].map(
+            self.config["status_codes_remap"]
+        )
+        if df_voter["StatusCode"].isnull().any():
+            missing = df_voter[
+                df_voter["StatusCode"].isnull()
+            ]["StatusCodeOrig"].to_list()
+            logging.warning("Status codes missing from status_codes_remap")
+            logging.warning(missing)
+
         # Check for missing columns; catch error because we're fixing them
         # below
         try:


### PR DESCRIPTION
Add a status code map and use that to adapt the status codes provided into a smaller set while preserving the originals in another column (`statuscodeorig`).

Fixes VoteShield/Inspector#959