### PR TITLE
add vermont abbreviation

### DIFF
--- a/reggie/configs/data/vermont.yaml
+++ b/reggie/configs/data/vermont.yaml
@@ -5,6 +5,7 @@
 file_type: .txt
 delimiter: '|'
 state: vermont
+abbreviation: vt
 source: boe
 file_class: voter_file
 has_headers: TRUE


### PR DESCRIPTION
Somehow Vermont's yaml snuck in without an abbreviation field, which is preventing notification emails from sending