### PR TITLE
Added User Agent to Ohio requests

### DIFF
--- a/reggie/ingestion/auto_download.py
+++ b/reggie/ingestion/auto_download.py
@@ -50,7 +50,7 @@ def state_download(state, s3_bucket):
             logging.info("downloading {} file".format(url))
             target_path = "/tmp/" + state + "_" + file_names[i] + ".txt.gz"
             zipped_files.append(target_path)
-            response = requests.get(url, stream=True, verify=False)
+            response = requests.get(url, stream=True, verify=False, headers={'User-Agent': 'VoteShield-Reggie/0.0.1'},)
             handle = open(target_path, "wb")
             for chunk in response.iter_content(chunk_size=512):
                 if chunk:

--- a/reggie/ingestion/download.py
+++ b/reggie/ingestion/download.py
@@ -44,7 +44,7 @@ from reggie.reggie_constants import (
 
 def ohio_get_last_updated():
     html = requests.get(
-        "https://www6.ohiosos.gov/ords/f?p=VOTERFTP:STWD", verify=False
+        "https://www6.ohiosos.gov/ords/f?p=VOTERFTP:STWD", verify=False, headers = {'User-Agent': 'VoteShield-Reggie/0.0.1'},
     ).text
     soup = bs4.BeautifulSoup(html, "html.parser")
     results = soup.find_all("td", {"headers": "DATE_MODIFIED"})


### PR DESCRIPTION
After meeting with the Ohio security team, we've added an identifying User Agent to our automated requests per their... request.  

The identifying User Agent is now  `VoteShield-Reggie/0.0.1`, which follows [RFC-7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3) for conventions. This has been tested and works for downloading.


 # How to test:

```python
import requests
requests.get("https://www6.ohiosos.gov/ords/f?p=VOTERFTP:STWD", verify=False,  headers={'User-Agent': 'VoteShield-Reggie/0.0.1'},).text
```