### PR TITLE
Add California language codes to yaml

### DIFF
--- a/reggie/configs/data/california.yaml
+++ b/reggie/configs/data/california.yaml
@@ -206,6 +206,18 @@ hist_columns:
   - ElectionDate
   - ElectionName
   - Method
+language_options:
+  'eng': english
+  'spa': spanish
+  'chn': chinese
+  'vtn': vietnamese
+  'kor': korean
+  'tag': tagalog
+  'oth': other
+  'jpn': japanese
+  'tha': thai
+  'hin': hindi
+  'khm': khmer
 county_names:
   Alameda: 1,
   Alpine: 2,


### PR DESCRIPTION
This is my best guess at what the language codes mean in California, based on supplemental info like https://statisticalatlas.com/state/California/Languages since CA does not give us a data key.