### PR TITLE
Bugfix/relaxing filecount checks

### DIFF
--- a/reggie/ingestion/download.py
+++ b/reggie/ingestion/download.py
@@ -612,7 +612,7 @@ class Preprocessor:
                     hist_files,
                 )
 
-        if expected_voter != voter_files:
+        if expected_voter > voter_files:
             logging.info(
                 "Incorrect number of voter files found, expected {}, found {}".format(
                     expected_voter, voter_files


### PR DESCRIPTION
This relaxes the check on filecounts, returning the error only if it is strictly less than the number expected