### PR TITLE
Exclude added readme in MN from expected file count

### DIFF
--- a/reggie/ingestion/preprocessor/minnesota_preprocessor.py
+++ b/reggie/ingestion/preprocessor/minnesota_preprocessor.py
@@ -37,8 +37,12 @@ class PreprocessMinnesota(Preprocessor):
             compression="unzip", file_obj=self.main_file
         )
 
+        # Exclude "readme.txt" (added Feb 2022) from files - doesn't count in expected number of files
+        new_files = [f for f in new_files if "readme.txt" not in f["name"].lower()]
+
         if not self.ignore_checks:
             self.file_check(len(new_files))
+
         voter_reg_df = pd.DataFrame(columns=self.config["ordered_columns"])
         voter_hist_df = pd.DataFrame(columns=self.config["hist_columns"])
         for i in new_files:


### PR DESCRIPTION
Minnesota decided to add a readme as a text file, which screws up our file count. So I'm just going to exclude it up front, since the expected number of real data files is still 16, and I can't guarantee whether or not this readme will be included in every package going forward.