### PR TITLE
More WV capitalization changes

### DIFF
--- a/reggie/ingestion/preprocessor/west_virginia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/west_virginia_preprocessor.py
@@ -96,6 +96,19 @@ class PreprocessWestVirginia(Preprocessor):
         if "mail unit" not in df_voters.columns.str.lower():
             df_voters["MAIL UNIT"] = np.nan
 
+        df_voters.rename(
+            columns={
+                "COUNTY_NAME": "County_Name",
+                "STATUS": "Status",
+                "SUFFIX": "Suffix",
+                "PARTYAFFILIATION": "PartyAffiliation",
+                "CONGRESSIONAL DISTRICT": "Congressional District",
+                "MAGISTERIAL DISTRICT": "Magisterial District",
+            },
+            inplace=True,
+            errors="ignore"
+        )
+
         # Apparently during redistricting the relevant fields will be dropped entirely
         # and then re-added to the file after updates.
         if "Senatorial District" not in df_voters.columns:
@@ -103,7 +116,6 @@ class PreprocessWestVirginia(Preprocessor):
         if "Delegate District" not in df_voters.columns:
             df_voters["Delegate District"] = np.nan
 
-        df_voters.rename(columns={"COUNTY_NAME": "County_Name", "STATUS": "Status", "SUFFIX": "Suffix"}, inplace=True, errors="ignore")
         # Add county id column
         df_voters.insert(
             1,


### PR DESCRIPTION
And moved the renames to before the district fill-in logic, since they are misnaming districts now too.