### PR TITLE
Fix typo in Dewey, OK

### DIFF
--- a/reggie/configs/primary_locale_names/county/oklahoma.json
+++ b/reggie/configs/primary_locale_names/county/oklahoma.json
@@ -20,7 +20,7 @@
   { "name": "Creek", "id": "creek" },
   { "name": "Custer", "id": "custer" },
   { "name": "Delaware", "id": "delaware" },
-  { "name": "Dewey", "id": "cewey" },
+  { "name": "Dewey", "id": "dewey" },
   { "name": "Ellis", "id": "ellis" },
   { "name": "Garfield", "id": "garfield" },
   { "name": "Garvin", "id": "garvin" },


### PR DESCRIPTION
Fixes a typo in Dewey Oklahoma, that Louie identified by noticing the locale matrix is wrong.