### PR TITLE
Correcting YAML files of what demographics are available in WI and NH

### DIFF
--- a/reggie/configs/data/new_hampshire.yaml
+++ b/reggie/configs/data/new_hampshire.yaml
@@ -18,7 +18,6 @@ republican_party: REP
 libertarian_party: LIB
 no_party_affiliation: UND
 demographic_fields_available:
-  - age
   - party
 absentee_ballot_code: "'Absentee'"
 date_format: '%m/%d/%Y'

--- a/reggie/configs/data/wisconsin.yaml
+++ b/reggie/configs/data/wisconsin.yaml
@@ -29,8 +29,6 @@ republican_party: None
 no_party_affiliation: 'NULL'
 missing_required_fields: true
 demographic_fields_available:
-  - age
-  - gender
 absentee_ballot_code: "'Absentee'"
 date_format: '%m/%d/%Y'
 generated_columns:


### PR DESCRIPTION
Incorrectly had Wisconsin and New Hampshire indicating that age was available for demographics. In reality, neither provide age, so I removed that from each YAML file.

This leaves Wisconsin with no demographics, but the existing metric code should just return NaNs in that case, which seems appropriate.