### PR TITLE
Add coerce_strings to Iowa, Georgia, Missouri, Pennsylvania

### DIFF
--- a/reggie/ingestion/preprocessor/georgia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/georgia_preprocessor.py
@@ -190,6 +190,7 @@ class PreprocessGeorgia(Preprocessor):
         gc.collect()
 
         df_voters = self.config.coerce_dates(df_voters)
+        df_voters = self.config.coerce_strings(df_voters)
         df_voters = self.config.coerce_numeric(
             df_voters,
             extra_cols=[

--- a/reggie/ingestion/preprocessor/georgia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/georgia_preprocessor.py
@@ -190,7 +190,7 @@ class PreprocessGeorgia(Preprocessor):
         gc.collect()
 
         df_voters = self.config.coerce_dates(df_voters)
-        df_voters = self.config.coerce_strings(df_voters)
+        df_voters = self.config.coerce_strings(df_voters, exclude=["Race", "Race_desc", "Gender"])
         df_voters = self.config.coerce_numeric(
             df_voters,
             extra_cols=[

--- a/reggie/ingestion/preprocessor/iowa_preprocessor.py
+++ b/reggie/ingestion/preprocessor/iowa_preprocessor.py
@@ -208,7 +208,7 @@ class PreprocessIowa(Preprocessor):
             )
 
         df_voters = self.config.coerce_dates(df_voters)
-        df_voters = self.config.coerce_strings(df_voters)
+        df_voters = self.config.coerce_strings(df_voters, exclude=["COUNTY", "GENDER"])
         df_voters = self.config.coerce_numeric(
             df_voters,
             extra_cols=[

--- a/reggie/ingestion/preprocessor/iowa_preprocessor.py
+++ b/reggie/ingestion/preprocessor/iowa_preprocessor.py
@@ -208,6 +208,7 @@ class PreprocessIowa(Preprocessor):
             )
 
         df_voters = self.config.coerce_dates(df_voters)
+        df_voters = self.config.coerce_strings(df_voters)
         df_voters = self.config.coerce_numeric(
             df_voters,
             extra_cols=[
@@ -220,6 +221,7 @@ class PreprocessIowa(Preprocessor):
                 "UNIT_NUM",
             ],
         )
+
         # force reg num to be integer
         df_voters["REGN_NUM"] = pd.to_numeric(
             df_voters["REGN_NUM"], errors="coerce"

--- a/reggie/ingestion/preprocessor/missouri_preprocessor.py
+++ b/reggie/ingestion/preprocessor/missouri_preprocessor.py
@@ -123,6 +123,7 @@ class PreprocessMissouri(Preprocessor):
         main_df.drop(self.config["hist_columns"], axis=1, inplace=True)
 
         main_df = self.config.coerce_dates(main_df)
+        main_df = self.config.coerce_strings(main_df)
         main_df = self.config.coerce_numeric(
             main_df,
             extra_cols=[

--- a/reggie/ingestion/preprocessor/missouri_preprocessor.py
+++ b/reggie/ingestion/preprocessor/missouri_preprocessor.py
@@ -123,7 +123,7 @@ class PreprocessMissouri(Preprocessor):
         main_df.drop(self.config["hist_columns"], axis=1, inplace=True)
 
         main_df = self.config.coerce_dates(main_df)
-        main_df = self.config.coerce_strings(main_df)
+        main_df = self.config.coerce_strings(main_df, exclude=["County"])
         main_df = self.config.coerce_numeric(
             main_df,
             extra_cols=[

--- a/reggie/ingestion/preprocessor/pennsylvania_preprocessor.py
+++ b/reggie/ingestion/preprocessor/pennsylvania_preprocessor.py
@@ -260,6 +260,7 @@ class PreprocessPennsylvania(Preprocessor):
 
         logging.info("coercing")
         main_df = config.coerce_dates(main_df)
+        main_df = self.config.coerce_strings(main_df)
         main_df = config.coerce_numeric(
             main_df,
             extra_cols=[

--- a/reggie/ingestion/preprocessor/pennsylvania_preprocessor.py
+++ b/reggie/ingestion/preprocessor/pennsylvania_preprocessor.py
@@ -260,7 +260,7 @@ class PreprocessPennsylvania(Preprocessor):
 
         logging.info("coercing")
         main_df = config.coerce_dates(main_df)
-        main_df = self.config.coerce_strings(main_df)
+        main_df = self.config.coerce_strings(main_df, exclude=["county", "gender"])
         main_df = config.coerce_numeric(
             main_df,
             extra_cols=[


### PR DESCRIPTION
Adds the standard coerce_strings function to preprocessors for Iowa, Georgia, Missouri, Pennsylvania. This has the effect of normalizing most string data in the incoming dataframe: lowercasing and stripping whitespace. Some data fields are excluded from this normalization until we are able to reprocess all of the data.