### PR TITLE
VA remove extra mailing_state from address_fields

### DIFF
--- a/reggie/configs/data/virginia.yaml
+++ b/reggie/configs/data/virginia.yaml
@@ -89,7 +89,6 @@ address_fields:
   - MAILING_ADDRESS_LINE_3
   - MAILING_CITY
   - MAILING_STATE
-  - MAILING_STATE
 format:
   separate_hist: true
   separate_counties_voter_file: false


### PR DESCRIPTION
In the virginia YAML, "MAILING_STATE" was in the address_fields config twice