### PR TITLE
Removing gender as a feature available in Vermont

### DIFF
--- a/reggie/configs/data/vermont.yaml
+++ b/reggie/configs/data/vermont.yaml
@@ -31,7 +31,6 @@ party_identifier: party_identifier
 missing_required_fields: true
 demographic_fields_available:
   - age
-  - gender
   - status
 name_fields:
   - Last Name


### PR DESCRIPTION
For some reason, I had gender as an available feature in Vermont, but it doesn't appear to be available. This removes it from the YAML file.