### PR TITLE
Add year-only option to date formats for Missouri

### DIFF
--- a/reggie/configs/data/missouri.yaml
+++ b/reggie/configs/data/missouri.yaml
@@ -10,7 +10,9 @@ county_identifier: County
 primary_locale_identifier: County
 numeric_primary_locale: false
 birthday_identifier: Birthdate
-date_format: '%m/%d/%Y'
+date_format:
+  - '%m/%d/%Y'
+  - '%Y'
 voter_status: voter_status
 voter_status_active: Active
 voter_status_inactive: Inactive


### PR DESCRIPTION
Missouri removed birthdates and now only give us birth years