### PR TITLE
Fixes bug if Oklahoma precincts data contains NaN values

### DIFF
--- a/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
+++ b/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
@@ -74,7 +74,11 @@ class PreprocessOklahoma(Preprocessor):
         # Read and merge the precincts file to the main df
         precinct_dtypes = {'PrecinctCode': 'string', 'CongressionalDistrict': 'int64', 'StateSenateDistrict': 'int64', 
                            'StateHouseDistrict': 'int64', 'CountyCommissioner': 'int64', 'PollSite': 'string'}
-        precincts = pd.read_csv(precincts_file["obj"], encoding='latin', dtype=precinct_dtypes)
+        precinct_ints = [k for k,v in precinct_dtypes.items() if v == "int64"]
+        precincts = pd.read_csv(precincts_file["obj"], encoding='latin')
+        precincts.dropna(subset=precinct_ints, inplace=True)
+        for k, v in precinct_dtypes.items():
+            precincts[k] = precincts[k].astype(v)
         precincts.rename(columns={"PrecinctCode": "Precinct"}, inplace=True)
         if precincts.empty:
             raise ValueError("Missing Precicnts file")

--- a/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
+++ b/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
@@ -75,7 +75,7 @@ class PreprocessOklahoma(Preprocessor):
         precinct_dtypes = {'PrecinctCode': 'string', 'CongressionalDistrict': 'int64', 'StateSenateDistrict': 'int64', 
                            'StateHouseDistrict': 'int64', 'CountyCommissioner': 'int64', 'PollSite': 'string'}
         precinct_ints = [k for k,v in precinct_dtypes.items() if v == "int64"]
-        precincts = pd.read_csv(precincts_file["obj"], encoding='latin')
+        precincts = pd.read_csv(precincts_file["obj"], encoding="latin")
         precincts.dropna(subset=precinct_ints, inplace=True)
         for k, v in precinct_dtypes.items():
             precincts[k] = precincts[k].astype(v)


### PR DESCRIPTION
**Addresses issue(s): https://voteshield.sentry.io/issues/4217137704/ **

## What this does
Newest Oklahoma precincts file contains a row of bad data with NaN values in columns that should be read as integers. It is impossible to read them directly with the NaN so this reads them, drops NaNs and then does the type conversions.

### Side effects
Hopefully none

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - Inspector PR TBD
