### PR TITLE
Convert Arizona AEVL back to PEVL

### DIFF
--- a/reggie/configs/data/arizona2.yaml
+++ b/reggie/configs/data/arizona2.yaml
@@ -170,6 +170,7 @@ column_aliases:
     DOB(Restricted): DOB
     NameSuffix: Suffix
     MailingAddressLine2: MailingAddress2
+    AEVL: PEVL
 generated_columns:
   all_history: text[]
   sparse_history: int[]


### PR DESCRIPTION
**Addresses issue(s): https://voteshield.sentry.io/issues/4221757694/

## What this does
Renames the new "AEVL column in Arizona back to PEVL. Arizona has renamed PEVL to AEVL, but it should be basically the same data as in our existing schema.

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **NO**
