### PR TITLE
New Georgia data formats

### DIFF
--- a/reggie/configs/data/georgia.yaml
+++ b/reggie/configs/data/georgia.yaml
@@ -22,6 +22,7 @@ no_party_affiliation: npa
 date_format:
   - '%Y'
   - '%Y%m%d'
+  - '%m/%d/%Y'
 missing_required_fields: true
 demographic_fields_available:
   - age
@@ -383,3 +384,69 @@ race_options:
   AP: asian_or_pacific_islander
   OT: other
   AI: american_indian_or_alaskan_native
+
+# 2023 column header update
+# new column name: original column name
+# (several different interim formats)
+column_aliases:
+    County: County_code
+    Voter Registration: Registration_Number
+    Voter Registration Number: Registration_Number
+    Status: Voter_status
+    Last Name: Last_name
+    First Name: First_name
+    Middle Name: Middle_maiden_name
+    Suffix: Name_suffix
+    'Street #': Residence_house_number
+    Residence Street Number: Residence_house_number
+    Street Name: Residence_street_name
+    Residence Street Name: Residence_street_name
+    'Apt #': Residence_apt_unit_nbr
+    Residence Apt Unit Number: Residence_apt_unit_nbr
+    City: Residence_city
+    Residence City: Residence_city
+    Zip Code: Residence_zipcode
+    Residence Zipcode: Residence_zipcode
+    Birth Year: Year_of_Birth
+    Registration Date: Registration_date
+    Land Districts: Land_district
+    Land District: Land_district
+    Land Lot: Land_lot
+    Status Reason: Status_reason
+    County Precinct: County_precinct_id
+    Municipal Precinct: City_precinct_id
+    CNG: Congressional_district
+    Congressional District: Congressional_district
+    SEN: Senate_district
+    State Senate District: Senate_district
+    HSE: House_district
+    State House District: House_district
+    JUD: Judicial_district
+    Judicial District: Judicial_district
+    COM: Commission_district
+    County Commission District: Commission_district
+    SCH: School_district
+    County School Board District: School_district
+    Municipality: Municipal_name
+    MUNIB: City_school_district_name
+    Municipal School Board District: City_school_district_name
+    Last Voted Date: Date_last_voted
+    Last Vote Date: Date_last_voted
+    Last Party Voted: Party_last_voted
+    Voter Created Date: Date_added
+    Last Modified Date: Date_changed
+    Combo#: District_combo
+    Combo Number: District_combo
+    Date of Last Contact: Last_contact_date
+    'Mailing Street #': Mail_house_nbr
+    Mailing Street Number: Mail_house_nbr
+    Mailing Street Name 1/PO Box: Mail_street_name
+    Mailing Street Name: Mail_street_name
+    Mailing Apt#/Lot#/Unit#: Mail_apt_unit_nbr
+    Mailing Apt Unit Number: Mail_apt_unit_nbr
+    Mailing City: Mail_city
+    Mailing State/FPO/APO: Mail_state
+    Mailing State: Mail_state
+    Mailing Zip Code: Mail_zip_code
+    Mailing Zipcode: Mail_zip_code
+    Mailing Country: Mail_country

--- a/reggie/configs/data/georgia.yaml
+++ b/reggie/configs/data/georgia.yaml
@@ -384,6 +384,13 @@ race_options:
   AP: asian_or_pacific_islander
   OT: other
   AI: american_indian_or_alaskan_native
+  White: white
+  Black: black
+  Hispanic/Latino: hispanic_or_latino
+  Asian/Pacific Islander: asian_or_pacific_islander
+  American Indian: american_indian
+  Refused: refused
+  Multi-Racial: multi_racial
 
 # 2023 column header update
 # new column name: original column name

--- a/reggie/ingestion/download.py
+++ b/reggie/ingestion/download.py
@@ -86,6 +86,10 @@ def get_object_mem(key, s3_bucket):
 
 
 def concat_and_delete(in_list):
+    """
+    Note: this only work for
+    files with NO header
+    """
     outfile = StringIO()
 
     for f_obj in in_list:

--- a/reggie/ingestion/download.py
+++ b/reggie/ingestion/download.py
@@ -85,14 +85,30 @@ def get_object_mem(key, s3_bucket):
     return file_obj
 
 
-def concat_and_delete(in_list):
+def concat_and_delete(in_list, has_headers=False):
     """
-    Note: this only work for
-    files with NO header
+    Take a list of FileItem objects,
+    and concat them into a single object
+    that can be read
+    :param in_list: list of file objects
+    :param has_headers: True if each file has a
+                        header, False otherwise
+    :return: combined file object
     """
     outfile = StringIO()
 
+    if has_headers:
+        write_header = True
+
     for f_obj in in_list:
+
+        if has_headers:
+            h = f_obj["obj"].readline()
+            # Write header only once
+            if write_header:
+                outfile.write(h.decode())
+                write_header = False
+
         s = f_obj["obj"].read()
         outfile.write(s.decode())
     outfile.seek(0)

--- a/reggie/ingestion/preprocessor/alaska_preprocessor.py
+++ b/reggie/ingestion/preprocessor/alaska_preprocessor.py
@@ -2,7 +2,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from dateutil import parser
 from reggie.ingestion.utils import (

--- a/reggie/ingestion/preprocessor/arizona_preprocessor.py
+++ b/reggie/ingestion/preprocessor/arizona_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     MissingNumColumnsError,

--- a/reggie/ingestion/preprocessor/connecticut_preprocessor.py
+++ b/reggie/ingestion/preprocessor/connecticut_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     MissingNumColumnsError,

--- a/reggie/ingestion/preprocessor/dc_preprocessor.py
+++ b/reggie/ingestion/preprocessor/dc_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     MissingNumColumnsError,

--- a/reggie/ingestion/preprocessor/delaware_preprocessor.py
+++ b/reggie/ingestion/preprocessor/delaware_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     MissingNumColumnsError,

--- a/reggie/ingestion/preprocessor/georgia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/georgia_preprocessor.py
@@ -95,18 +95,20 @@ class PreprocessGeorgia(Preprocessor):
         # Georgia fully overhauled its voter reg system in 2023, with
         # several different interim formats coming through over several months
         sep = "|"
+        quoting = 3
         file_date = datetime.strptime(date_from_str(self.raw_s3_file), "%Y-%m-%d")
         if file_date > datetime(2023, 2, 5):
             header_arg = 0
         if file_date > datetime(2023, 3, 13):
             sep = ","
+            quoting = 0
 
         df_voters = self.read_csv_count_error_lines(
             voter_files[0]["obj"],
             sep=sep,
             header=header_arg,
             quotechar='"',
-            quoting=3,
+            quoting=quoting,
             on_bad_lines="warn",
         )
         del voter_files

--- a/reggie/ingestion/preprocessor/georgia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/georgia_preprocessor.py
@@ -167,8 +167,7 @@ class PreprocessGeorgia(Preprocessor):
         logging.info("Reading old-style history files")
         history = self.read_csv_count_error_lines(
             concat_history_file_old,
-            sep="  ",
-            names=["Concat_str", "Other"],
+            names=["Concat_str"],
             on_bad_lines="warn",
         )
         del concat_history_file_old
@@ -179,9 +178,10 @@ class PreprocessGeorgia(Preprocessor):
         history["Election_Date"] = history["Concat_str"].str[11:19]
         history["Election_Type"] = history["Concat_str"].str[19:22]
         history["Party"] = history["Concat_str"].str[22:24]
-        history["Absentee"] = history["Other"].str[0]
-        history["Provisional"] = history["Other"].str[1]
-        history["Supplemental"] = history["Other"].str[2]
+
+        history["Absentee"] = history["Concat_str"].str[24]
+        history["Provisional"] = history["Concat_str"].str[25]
+        history["Supplemental"] = history["Concat_str"].str[26]
         type_dict = {
             "001": "GEN_PRIMARY",
             "002": "GEN_PRIMARY_RUNOFF",
@@ -195,6 +195,12 @@ class PreprocessGeorgia(Preprocessor):
             "010": "PPP",
         }
         history = history.replace({"Election_Type": type_dict})
+
+        # Year the date format switched from "%m%d%Y" to "%Y%m%d"
+        date_format_switch = "2013"
+        history["Election_Date"] = history["Election_Date"].map(
+            lambda x: x[4:8] + x[0:2] + x[2:4] if x[0:4] < date_format_switch else x
+        )
 
         # If they exist, read new-style history files
         if len(vh_files_new_style) > 0:

--- a/reggie/ingestion/preprocessor/georgia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/georgia_preprocessor.py
@@ -260,12 +260,6 @@ class PreprocessGeorgia(Preprocessor):
         history = history.filter(
             items=[
                 "Registration_Number",
-                "Election_Date",
-                "Election_Type",
-                "Party",
-                "Absentee",
-                "Provisional",
-                "Supplemental",
                 "Combo_history",
             ]
         )

--- a/reggie/ingestion/preprocessor/maryland_preprocessor.py
+++ b/reggie/ingestion/preprocessor/maryland_preprocessor.py
@@ -13,7 +13,6 @@ import pandas as pd
 from reggie.ingestion.download import (
     FileItem,
     Preprocessor,
-    concat_and_delete,
     date_from_str,
 )
 from reggie.ingestion.utils import (

--- a/reggie/ingestion/preprocessor/montana_preprocessor.py
+++ b/reggie/ingestion/preprocessor/montana_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     MissingNumColumnsError,

--- a/reggie/ingestion/preprocessor/new_jersey_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_jersey_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     MissingNumColumnsError,

--- a/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
+++ b/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
@@ -15,7 +15,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     format_column_name,

--- a/reggie/ingestion/preprocessor/oregon_preprocessor.py
+++ b/reggie/ingestion/preprocessor/oregon_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     format_column_name,

--- a/reggie/ingestion/preprocessor/rhode_island_preprocessor.py
+++ b/reggie/ingestion/preprocessor/rhode_island_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     format_column_name,

--- a/reggie/ingestion/preprocessor/south_dakota_preprocessor.py
+++ b/reggie/ingestion/preprocessor/south_dakota_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     format_column_name,

--- a/reggie/ingestion/preprocessor/vermont_preprocessor.py
+++ b/reggie/ingestion/preprocessor/vermont_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     format_column_name,

--- a/reggie/ingestion/preprocessor/washington_preprocessor.py
+++ b/reggie/ingestion/preprocessor/washington_preprocessor.py
@@ -15,7 +15,6 @@ from reggie.reggie_constants import NO_PARTY_PLACEHOLDER
 from reggie.ingestion.download import (
     FileItem,
     Preprocessor,
-    concat_and_delete,
     date_from_str,
 )
 from reggie.ingestion.utils import (

--- a/reggie/ingestion/preprocessor/west_virginia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/west_virginia_preprocessor.py
@@ -22,7 +22,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     InvalidDataError,

--- a/reggie/ingestion/preprocessor/wyoming_preprocessor.py
+++ b/reggie/ingestion/preprocessor/wyoming_preprocessor.py
@@ -14,7 +14,6 @@ from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
-    concat_and_delete,
 )
 from reggie.ingestion.utils import (
     MissingNumColumnsError,


### PR DESCRIPTION
**Addresses issue(s): https://github.com/Voteshield/Inspector/issues/1674**

## What this does
Adjust the Georgia preprocessor and yaml to accommodate ingesting the *several different* new-style files that Georgia has given us recently (March, April, May 2023). The schema has changed a bit, but this PR attempts to map the new schema back to our existing fields, to avoid the need for a "georgia2" schema. Some data values such as "voter status" are also re-mapped to match the existing data, so we do not need to track multiple code values. This PR also changes the handling of Georgia's newer history files, since that format has also been changed (to be much more interpretable, thankfully).

The data analysts in the Georgia SOS office have not (yet?) provided me with a matching key, so some of these mappings are my best guess, but only for somewhat less important fields (e.g. does "Municipality" = "Municipal_name" ?). Also, I've been warned that future Georgia files may diverge again until the end of summer 2023, but shouldn't be too far off from what we have seen currently.

### Side effects
We are losing some small amount of new data, which doesn't fit into our existing schema. Should be very negligible fields though.

## How to test
Process one of the new 2023 Georgia files

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [x] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - TBD in Inspector
