### PR TITLE
Combine Georgia address fields

### DIFF
--- a/reggie/ingestion/preprocessor/georgia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/georgia_preprocessor.py
@@ -198,7 +198,6 @@ class PreprocessGeorgia(Preprocessor):
                 columns=self.config["column_aliases"],
                 inplace=True,
             )
-
             df_voters = self.reconcile_columns(df_voters, self.config["columns"])
             df_voters["Race_desc"] = df_voters["Race"]
 

--- a/reggie/ingestion/preprocessor/georgia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/georgia_preprocessor.py
@@ -190,7 +190,7 @@ class PreprocessGeorgia(Preprocessor):
                     "Residence Post Direction"
                 ]
                 df_voters["Residence Street Name"] = combine_street_name_fields(
-                    df_voters[street_name_fields], street_name_fields
+                    df_voters[street_name_fields].copy(), street_name_fields
                 )
 
             # New 2023 files need a lot of renaming of columns


### PR DESCRIPTION
**Addresses issue(s): Issue raised by Jiamin last week that there were a number of spurious address changes showing up in Georgia, due to how they have recently split up their street name data **

## What this does
For the 2 most recent (May, June 2023) Georgia files, this PR will combine the newly split out fields ("Residence Street Type", "Residence Pre Direction", and "Residence Post Direction") back into "Residence Street Name", so that hopefully there will be less spurious address changes appearing in Georgia throughout this data normalization process.

### Side effects
Hopefully none

## Checklist
- [ ] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - TBD in Inspector
