### PR TITLE
Bugfixes for Georgia and Arizona2

### DIFF
--- a/reggie/configs/data/arizona2.yaml
+++ b/reggie/configs/data/arizona2.yaml
@@ -171,6 +171,7 @@ column_aliases:
     NameSuffix: Suffix
     MailingAddressLine2: MailingAddress2
     AEVL: PEVL
+    RegistrantCounty: County
 generated_columns:
   all_history: text[]
   sparse_history: int[]

--- a/reggie/ingestion/preprocessor/arizona2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/arizona2_preprocessor.py
@@ -34,7 +34,7 @@ class PreprocessArizona2(Preprocessor):
             self.main_file = self.s3_download()
 
         def file_is_active(filename):
-            for word in ["Canceled", "Suspense", "Inactive"]:
+            for word in ["Canceled", "Suspense", "Inactive", "Cancelled", "NotReg"]:
                 if word in filename:
                     return False
             return True

--- a/reggie/ingestion/preprocessor/georgia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/georgia_preprocessor.py
@@ -54,11 +54,11 @@ class PreprocessGeorgia(Preprocessor):
         # Georgia likes changing the name of its voter file
         possible_voterfile_names = [
             "georgia_daily_voterbase",
-            "statewidevoterlist",
-            "statewide_voter_list",
             "gdvb",
-            "georgia_state_wide_voter_file",
-            "statewide voter file",
+            "statewidevoter",
+            "statewide_voter",
+            "statewide voter",
+            "state_wide_voter",
         ]
 
         for i in new_files:


### PR DESCRIPTION
**Addresses issue(s): https://voteshield.sentry.io/issues/4266529743/?project=5552704&query=is%3Aunresolved&referrer=issue-stream&stream_index=2 and https://voteshield.sentry.io/issues/4221757694/?project=5552704&query=is%3Aunresolved&referrer=issue-stream&stream_index=1**

## What this does
Bugfixes:
- Generalizes Georgia file names further
- Reverts changed field name RegistrantCounty back to County in Arizona2

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - TBD update in Inspector
