### PR TITLE
Bugfix Washington birthdate to birthyear

### DIFF
--- a/reggie/configs/data/washington.yaml
+++ b/reggie/configs/data/washington.yaml
@@ -11,6 +11,7 @@ fixed_width: false
 date_format:
   - "%m/%d/%Y"
   - "%Y-%m-%d"
+  - "%Y"
 county_identifier: CountyCode
 primary_locale_identifier: CountyCode
 numeric_primary_locale: FALSE

--- a/reggie/ingestion/preprocessor/washington_preprocessor.py
+++ b/reggie/ingestion/preprocessor/washington_preprocessor.py
@@ -136,6 +136,11 @@ class PreprocessWashington(Preprocessor):
         )
 
         # --- handling the voter file --- #
+        # Aug 2023 - some columns have changed names slightly
+        df_voter.rename(
+            columns={"Birthyear": "Birthdate", "RegStUnitNum": "RegUnitNum"},
+            inplace=True,
+        )
         # some columns have become obsolete
         df_voter = df_voter.loc[
             :, df_voter.columns.isin(self.config["column_names"])


### PR DESCRIPTION
**Addresses issue(s): Recurring ML job and missing birth dates in recent Washington files -->**

## What this does
Correctly parses the recently changed birthdate to birthyear field in Washington files. Also converts an address field that had an apparent name change to the previous name.

### Side effects
Should be none

## How to test
Run Sept or Oct Washington file and see that birthdate is now processed correctly

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [x] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - TBD in Inspector
