### PR TITLE
Add explicit list of "not registered" statuses in states that have them

### DIFF
--- a/reggie/configs/data/arizona.yaml
+++ b/reggie/configs/data/arizona.yaml
@@ -35,6 +35,10 @@ voter_status_suspense: 'S   '
 voter_status_cancelled: 'R   '
 voter_status_not_eligible: 'N   '
 voter_status_not_registered: 'NR  '
+not_registered_voter_status_set:
+  - 'R   '
+  - 'N   '
+  - 'NR  '
 democratic_party: DEMOCRATIC
 republican_party: REPUBLICAN
 no_party_affiliation: "PARTY NOT DESIGNATED"

--- a/reggie/configs/data/arizona2.yaml
+++ b/reggie/configs/data/arizona2.yaml
@@ -22,6 +22,12 @@ voter_status_active: active
 voter_status_inactive: inactive
 voter_status_suspense: suspense
 voter_status_cancelled: canceled
+voter_status_not_eligible: 'not eligible'
+voter_status_not_registered: 'not registered'
+not_registered_voter_status_set:
+  - canceled
+  - 'not eligible'
+  - 'not registered'
 party_identifier: Party
 democratic_party: dem
 republican_party: rep

--- a/reggie/configs/data/michigan.yaml
+++ b/reggie/configs/data/michigan.yaml
@@ -17,8 +17,9 @@ voter_status: VOTER_STATUS_TYPE_CODE
 voter_status_active: A
 voter_status_inactive: V
 voter_status_cancelled: C
-voter_status_rejected: R
 voter_status_challenged: CH
+not_registered_voter_status_set:
+  - C
 absentee_ballot_code: "'Y'"
 democratic_party: None
 republican_party: None

--- a/reggie/configs/data/minnesota.yaml
+++ b/reggie/configs/data/minnesota.yaml
@@ -10,6 +10,7 @@ primary_locale_identifier: CountyCode
 numeric_primary_locale: true
 birthday_identifier: DOBYear
 voter_status: voter_status
+# These are only placeholder values, there is no voter status data provided in Minnesota
 voter_status_active: Active
 voter_status_inactive: Inactive
 no_party_affiliation: NPA

--- a/reggie/configs/data/missouri.yaml
+++ b/reggie/configs/data/missouri.yaml
@@ -14,6 +14,7 @@ date_format:
   - '%m/%d/%Y'
   - '%Y'
 voter_status: voter_status
+# Missouri used to provide voter status data, but doesn't any longer
 voter_status_active: Active
 voter_status_inactive: Inactive
 party_identifier: party_identifier

--- a/reggie/configs/data/new_hampshire.yaml
+++ b/reggie/configs/data/new_hampshire.yaml
@@ -10,6 +10,7 @@ primary_locale_identifier: County
 numeric_primary_locale: false
 birthday_identifier: birth_date
 voter_status: voter_status
+# These are only placeholder values, there is no voter status data provided in NH
 voter_status_active: active
 voter_status_inactive: inactive
 party_identifier: cd_party

--- a/reggie/configs/data/new_york.yaml
+++ b/reggie/configs/data/new_york.yaml
@@ -31,6 +31,8 @@ status_codes_remap:
   AF: AF
   AP: AP
   AU: AU
+not_registered_voter_status_set:
+  - PURGED
 reason_code: reasoncode
 democratic_party: DEM
 republican_party: REP

--- a/reggie/configs/data/new_york.yaml
+++ b/reggie/configs/data/new_york.yaml
@@ -33,6 +33,7 @@ status_codes_remap:
   AU: AU
 not_registered_voter_status_set:
   - PURGED
+max_duplicate_voters: 8.0
 reason_code: reasoncode
 democratic_party: DEM
 republican_party: REP

--- a/reggie/configs/data/north_carolina.yaml
+++ b/reggie/configs/data/north_carolina.yaml
@@ -16,8 +16,9 @@ voter_status: status_cd
 voter_status_active: A
 voter_status_inactive: I
 voter_status_cancelled: R
-voter_status_denied: D
 voter_status_temporary: S
+not_registered_voter_status_set:
+  - R
 reason_code: voter_status_reason_desc
 democratic_party: DEM
 republican_party: REP

--- a/reggie/configs/data/pennsylvania.yaml
+++ b/reggie/configs/data/pennsylvania.yaml
@@ -16,6 +16,7 @@ provisional_ballot_code: P
 voter_status: voter_status
 voter_status_active: A
 voter_status_inactive: I
+# There is a very rarely used voter status: "D", is this denied?
 party_identifier: party_identifier
 democratic_party: D
 republican_party: R

--- a/reggie/configs/data/texas.yaml
+++ b/reggie/configs/data/texas.yaml
@@ -12,6 +12,8 @@ voter_status: Status_Code
 voter_status_active: V
 voter_status_inactive: S
 voter_status_cancelled: C
+not_registered_voter_status_set:
+  - C
 party_identifier: party_identifier
 expected_number_of_files: 510
 no_party_affiliation: npa

--- a/reggie/configs/data/virginia.yaml
+++ b/reggie/configs/data/virginia.yaml
@@ -15,6 +15,10 @@ voter_status_active: Active
 voter_status_inactive: Inactive
 voter_status_incomplete: Incomplete
 voter_status_cancelled: Cancelled
+voter_status_denied: Denied
+not_registered_voter_status_set:
+  - Cancelled
+  - Denied
 democratic_party: Democrat
 republican_party: Republican
 no_party_affiliation: 'NULL'

--- a/reggie/configs/data/wisconsin.yaml
+++ b/reggie/configs/data/wisconsin.yaml
@@ -23,6 +23,8 @@ voter_status: voter_status
 voter_status_active: Active
 voter_status_inactive: None
 voter_status_cancelled: Inactive
+not_registered_voter_status_set:
+  - Inactive
 reason_code: voter_status_reason
 democratic_party: None
 republican_party: None


### PR DESCRIPTION
**Addresses issue(s): https://app.asana.com/0/1205510425969296/1205693426847839/f and https://app.asana.com/0/1205510425969296/1205690292791127/f -->**

## What this does
Adds a new list value ("not_registered_voter_status_set") to the yaml for states with one or more statuses for voters who are *not actually registered voters*.

Previously we had assumed that the only "non-registered" status in any file was a single "cancelled" status. In reality, several states have records for other types of voters who are not actually part of the registered voter population. Some examples: cancelled, denied, not eligible, not registered.

We need a way to group these statuses so they can all be excluded from voter populations at the same time, so this new "not_registered_voter_status_set" list is being introduced.

This PR also includes a few corrections and notes, as I was checking the set of statuses in each state.

## How to test
Install reggie and see that some yaml configs now have a new value, not_registered_voter_status_set.

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [x] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - [Related pull request](https://github.com/Voteshield/Inspector/pull/1770)
