### PR TITLE
Fix Oklahoma registration date column name to get that data back

### DIFF
--- a/reggie/configs/data/oklahoma.yaml
+++ b/reggie/configs/data/oklahoma.yaml
@@ -185,6 +185,7 @@ dtypes:
   Zip: string
   stringOfBirth: string
   OriginalRegistration: string
+  RegistrationDate: string
   MailStreet1: string
   MailStreet2: string
   MailCity: string

--- a/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
+++ b/reggie/ingestion/preprocessor/oklahoma_preprocessor.py
@@ -67,6 +67,14 @@ class PreprocessOklahoma(Preprocessor):
         for file in voter_files:
             if "vr.csv" in file["name"].lower():
                 temp_vdf = pd.read_csv(file["obj"], encoding='latin', dtype=dtypes)
+
+                # Registration date column name changed at some point
+                if "RegistrationDate" in temp_vdf.columns:
+                    temp_vdf.rename(
+                        columns={"RegistrationDate": "OriginalRegistration"},
+                        inplace=True,
+                    )
+
                 vdf = pd.concat([vdf, temp_vdf], ignore_index=True)
         vdf.drop_duplicates(inplace=True)
 


### PR DESCRIPTION
**Addresses issue(s): Oklahoma changed their registration date column name at some point in the past **

## What this does
Manually changes the registration date column name back to the original name, so we can get the data into our schema.

### Side effects
Should be none.

## How to test
Process an Oklahoma file

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [x] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - TBD in Inspector
