### PR TITLE
Allow Nevada county voter IDs to come in as numeric or string

### DIFF
--- a/reggie/ingestion/preprocessor/nevada_preprocessor.py
+++ b/reggie/ingestion/preprocessor/nevada_preprocessor.py
@@ -103,10 +103,17 @@ class PreprocessNevada(Preprocessor):
         )
 
         # create compound string for unique voter ID from county ID
+        def format_county_id(vid):
+            try:
+                vid = int(float(vid))
+            except ValueError:
+                pass
+            return str(vid)
+
         df_voters["County_Voter_ID"] = (
             df_voters["County"].str.replace(" ", "").str.lower()
             + "_"
-            + df_voters["County_Voter_ID"].astype(int).astype(str)
+            + df_voters["County_Voter_ID"].map(format_county_id)
         )
         df_voters = self.config.coerce_dates(df_voters)
         df_voters = self.config.coerce_numeric(


### PR DESCRIPTION
**Addresses issue(s): Allow incoming county voter IDs to be numeric or string **

## What this does
This address an issue that occurs when we fix the "dual entry" database switch-over problem in Clark county Nevada in the summer of 2023. To fix the problem, we are adding unique strings to newly registered Clark voters so that they will not share an ID with any other voter after the database switch-over occurs in September. To ensure these are unique, we add the string "-DE" for dual entry. This bugfix just prevents an error from occuring for these voter IDs that are now strings and not purely numeric. Should not change anything else about the file processing.

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - Inspector TBD
