### PR TITLE
Refactor to allow multiple inactive and active statuses per state

### DIFF
--- a/reggie/configs/data/arizona.yaml
+++ b/reggie/configs/data/arizona.yaml
@@ -29,16 +29,16 @@ numeric_primary_locale: false
 birthday_identifier: year_of_birth
 early_voter_identifier: perm_absentee_indicator
 voter_status: cde_registrant_status
-voter_status_active: 'A   '
-voter_status_inactive: 'I   '
-voter_status_suspense: 'S   '
+voter_status_active:
+  - 'A   '
+voter_status_inactive:
+  - 'I   '
+# voter_status_suspense: 'S   '
 voter_status_cancelled: 'R   '
-voter_status_not_eligible: 'N   '
-voter_status_not_registered: 'NR  '
 not_registered_voter_status_set:
-  - 'R   '
-  - 'N   '
-  - 'NR  '
+  - 'R   ' # cancelled
+  - 'N   ' # not eligible
+  - 'NR  ' # not registered
 democratic_party: DEMOCRATIC
 republican_party: REPUBLICAN
 no_party_affiliation: "PARTY NOT DESIGNATED"

--- a/reggie/configs/data/arizona.yaml
+++ b/reggie/configs/data/arizona.yaml
@@ -33,12 +33,16 @@ voter_status_active:
   - 'A   '
 voter_status_inactive:
   - 'I   '
-# voter_status_suspense: 'S   '
 voter_status_cancelled: 'R   '
 not_registered_voter_status_set:
   - 'R   ' # cancelled
   - 'N   ' # not eligible
   - 'NR  ' # not registered
+#  - 'S   ' # suspense
+# Clint: "It appears from media reports that 'suspense' in AZ is a 'not registered'.
+# They can't vote because the voter needs to provide more info to election officials."
+# But Clint thinks we should leave it in the file for now, until we find out more.
+
 democratic_party: DEMOCRATIC
 republican_party: REPUBLICAN
 no_party_affiliation: "PARTY NOT DESIGNATED"

--- a/reggie/configs/data/arizona2.yaml
+++ b/reggie/configs/data/arizona2.yaml
@@ -22,12 +22,16 @@ voter_status_active:
   - active
 voter_status_inactive:
   - inactive
-# voter_status_suspense: suspense
 voter_status_cancelled: canceled
 not_registered_voter_status_set:
   - canceled
   - 'not eligible'
   - 'not registered'
+#  - suspense
+# Clint: "It appears from media reports that 'suspense' in AZ is a 'not registered'.
+# They can't vote because the voter needs to provide more info to election officials."
+# But Clint thinks we should leave it in the file for now, until we find out more.
+
 party_identifier: Party
 democratic_party: dem
 republican_party: rep

--- a/reggie/configs/data/arizona2.yaml
+++ b/reggie/configs/data/arizona2.yaml
@@ -18,12 +18,12 @@ precinct_identifier: Precinct
 birthday_identifier: DOB
 early_voter_identifier: PEVL
 voter_status: Status
-voter_status_active: active
-voter_status_inactive: inactive
-voter_status_suspense: suspense
+voter_status_active:
+  - active
+voter_status_inactive:
+  - inactive
+# voter_status_suspense: suspense
 voter_status_cancelled: canceled
-voter_status_not_eligible: 'not eligible'
-voter_status_not_registered: 'not registered'
 not_registered_voter_status_set:
   - canceled
   - 'not eligible'

--- a/reggie/configs/data/california.yaml
+++ b/reggie/configs/data/california.yaml
@@ -14,9 +14,11 @@ numeric_primary_locale: true
 birthday_identifier: DOB
 voter_status: Status
 # CA only supplies us with voters who have the active status
-voter_status_active: A
+voter_status_active:
+  - A
 # This does not exist in the files currently, if we get updated files this may need to be modified
-voter_status_inactive: I
+voter_status_inactive:
+  - I
 reason_code: VoterStatusReasonCodeDesc
 democratic_party: DEM
 republican_party: REP

--- a/reggie/configs/data/colorado.yaml
+++ b/reggie/configs/data/colorado.yaml
@@ -10,8 +10,10 @@ primary_locale_identifier: COUNTY
 numeric_primary_locale: false
 birthday_identifier: BIRTH_YEAR
 voter_status: STATUS
-voter_status_active: Active
-voter_status_inactive: Inactive
+voter_status_active:
+  - Active
+voter_status_inactive:
+  - Inactive
 reason_code: status_reason
 absentee_ballot_code: Mail
 democratic_party: DEM

--- a/reggie/configs/data/florida.yaml
+++ b/reggie/configs/data/florida.yaml
@@ -12,8 +12,10 @@ numeric_primary_locale: false
 precinct_identifier: Precinct_Split
 birthday_identifier: Birth_Date
 voter_status: Voter_Status
-voter_status_active: ACT
-voter_status_inactive: INA
+voter_status_active:
+  - ACT
+voter_status_inactive:
+  - INA
 voter_status_preregistered: PRE
 absentee_ballot_code: "'A'"
 democratic_party: DEM

--- a/reggie/configs/data/georgia.yaml
+++ b/reggie/configs/data/georgia.yaml
@@ -12,8 +12,10 @@ numeric_primary_locale: true
 precinct_identifier: County_precinct_id
 birthday_identifier: Year_of_Birth
 voter_status: Voter_status
-voter_status_active: A
-voter_status_inactive: I
+voter_status_active:
+  - A
+voter_status_inactive:
+  - I
 reason_code: status_reason
 party_identifier: party_identifier
 democratic_party: None

--- a/reggie/configs/data/iowa.yaml
+++ b/reggie/configs/data/iowa.yaml
@@ -13,10 +13,11 @@ numeric_primary_locale: false
 precinct_identifier: PRECINCT
 birthday_identifier: BIRTHDATE
 voter_status: VOTERSTATUS
-voter_status_active: Active
-voter_status_inactive: Inactive
-voter_status_pending: Pending
-voter_status_null:
+voter_status_active:
+  - Active
+voter_status_inactive:
+  - Inactive
+voter_status_preregistered: Pending
 demographic_fields_available:
   - age
   - gender

--- a/reggie/configs/data/kansas.yaml
+++ b/reggie/configs/data/kansas.yaml
@@ -10,8 +10,11 @@ primary_locale_identifier: db_logid
 numeric_primary_locale: false
 birthday_identifier: date_of_birth
 voter_status: cde_registrant_status
-voter_status_active: A
-voter_status_inactive: I
+voter_status_active:
+  - A
+voter_status_inactive:
+  - I
+# an unknown voter status: S
 democratic_party: Democratic
 republican_party: Republican
 libertarian_party: Libertarian

--- a/reggie/configs/data/kansas.yaml
+++ b/reggie/configs/data/kansas.yaml
@@ -14,7 +14,7 @@ voter_status_active:
   - A
 voter_status_inactive:
   - I
-# an unknown voter status: S
+# There is an unknown voter status in the file: S
 democratic_party: Democratic
 republican_party: Republican
 libertarian_party: Libertarian

--- a/reggie/configs/data/michigan.yaml
+++ b/reggie/configs/data/michigan.yaml
@@ -14,10 +14,12 @@ precinct_identifier: PRECINCT
 birthday_identifier: YEAR_OF_BIRTH
 early_voter_identifier: IS_PERMANENT_ABSENTEE_VOTER
 voter_status: VOTER_STATUS_TYPE_CODE
-voter_status_active: A
-voter_status_inactive: V
+voter_status_active:
+  - A
+voter_status_inactive:
+  - V   # inactive
+  - CH  # challenged
 voter_status_cancelled: C
-voter_status_challenged: CH
 not_registered_voter_status_set:
   - C
 absentee_ballot_code: "'Y'"

--- a/reggie/configs/data/minnesota.yaml
+++ b/reggie/configs/data/minnesota.yaml
@@ -11,8 +11,10 @@ numeric_primary_locale: true
 birthday_identifier: DOBYear
 voter_status: voter_status
 # These are only placeholder values, there is no voter status data provided in Minnesota
-voter_status_active: Active
-voter_status_inactive: Inactive
+voter_status_active:
+  - Active
+voter_status_inactive:
+  - Inactive
 no_party_affiliation: NPA
 party_identifier: party_identifier
 democratic_party: Democrat

--- a/reggie/configs/data/missouri.yaml
+++ b/reggie/configs/data/missouri.yaml
@@ -13,10 +13,12 @@ birthday_identifier: Birthdate
 date_format:
   - '%m/%d/%Y'
   - '%Y'
-voter_status: voter_status
 # Missouri used to provide voter status data, but doesn't any longer
-voter_status_active: Active
-voter_status_inactive: Inactive
+voter_status: voter_status
+voter_status_active:
+  - Active
+voter_status_inactive:
+  - Inactive
 party_identifier: party_identifier
 democratic_party: Democrat
 republican_party: Republican

--- a/reggie/configs/data/nevada.yaml
+++ b/reggie/configs/data/nevada.yaml
@@ -16,10 +16,11 @@ numeric_primary_locale: false
 precinct_identifier: Registered_Precinct
 birthday_identifier: Birth_Date
 voter_status: County_Status
-voter_status_active: Active
-voter_status_inactive: Inactive
-voter_status_waitlist: P-17
-voter_status_null:
+voter_status_active:
+  - Active
+voter_status_inactive:
+  - Inactive
+voter_status_preregistered: P-17
 democratic_party: Democrat
 republican_party: Republican
 no_party_affiliation: Non-Partisan

--- a/reggie/configs/data/new_hampshire.yaml
+++ b/reggie/configs/data/new_hampshire.yaml
@@ -11,8 +11,10 @@ numeric_primary_locale: false
 birthday_identifier: birth_date
 voter_status: voter_status
 # These are only placeholder values, there is no voter status data provided in NH
-voter_status_active: active
-voter_status_inactive: inactive
+voter_status_active:
+  - active
+voter_status_inactive:
+  - inactive
 party_identifier: cd_party
 democratic_party: DEM
 republican_party: REP

--- a/reggie/configs/data/new_jersey.yaml
+++ b/reggie/configs/data/new_jersey.yaml
@@ -10,13 +10,16 @@ primary_locale_identifier: county
 numeric_primary_locale: false
 birthday_identifier: dob
 voter_status: status
-voter_status_active: Active
-voter_status_inactive: Inactive #ID combined with IF
-voter_status_active_need_id: Active Need ID #voters need to provide ID or SS after registering
-voter_status_active_federal_only: Active-Federal Election Only #very few, to avoid violating NVRA
-voter_status_pending: Pending #minors
-voter_status_inactive_need_id: Inactive Confirmation-Need ID #funneling this and IF into I
-voter_status_inactive_confirmation: Inactive Confirmation #havent voted in several elections
+voter_status_active:
+  - Active
+  - 'Active Need ID'  # voters need to provide ID or SS after registering
+  - 'Active-Federal Election Only' # very few, to avoid violating NVRA
+voter_status_inactive:
+  - Inactive #ID combined with IF
+voter_status_preregistered: Pending # minors
+# These 2 Inactive statuses are edited in the preprocessor and consolidated into "Inactive":
+# Inactive Confirmation-Need ID # funneling this and IF into I
+# Inactive Confirmation # havent voted in several elections
 date_format: "%m/%d/%Y"
 party_identifier: party_code
 democratic_party: DEM

--- a/reggie/configs/data/new_jersey2.yaml
+++ b/reggie/configs/data/new_jersey2.yaml
@@ -19,9 +19,11 @@ date_format:
   - "%Y-%m-%d"
   - "%Y-%m-%d %H:%M:%S"
 voter_status: status
-voter_status_active: Active
-voter_status_inactive: Inactive
-voter_status_pending: Pending
+voter_status_active:
+  - Active
+voter_status_inactive:
+  - Inactive
+voter_status_preregistered: Pending
 party_identifier: party
 democratic_party: Democratic
 republican_party: Republican

--- a/reggie/configs/data/new_york.yaml
+++ b/reggie/configs/data/new_york.yaml
@@ -13,14 +13,18 @@ primary_locale_identifier: countycode
 numeric_primary_locale: true
 birthday_identifier: dob
 voter_status: status
-voter_status_active: ACTIVE
-voter_status_inactive: INACTIVE
+voter_status_active:
+  - ACTIVE
+  - AM  # active military
+  - AF  # active special federal
+  - AP  # active special presidential
+  - AU  # active uocava
+voter_status_inactive:
+  - INACTIVE
 voter_status_preregistered: PREREG
 voter_status_cancelled: PURGED
-voter_status_active_military: AM
-voter_status_active_special_federal: AF
-voter_status_active_special_presidential: AP
-voter_status_uocava: AU
+not_registered_voter_status_set:
+  - PURGED
 # in Dec 2021, NY started using abbreviations only
 status_codes_remap:
   A: ACTIVE
@@ -31,8 +35,6 @@ status_codes_remap:
   AF: AF
   AP: AP
   AU: AU
-not_registered_voter_status_set:
-  - PURGED
 max_duplicate_voters: 8.0
 reason_code: reasoncode
 democratic_party: DEM

--- a/reggie/configs/data/north_carolina.yaml
+++ b/reggie/configs/data/north_carolina.yaml
@@ -13,10 +13,13 @@ precinct_identifier: precinct_abbrv
 birthday_identifier: birth_year
 early_voter_identifier: absent_ind
 voter_status: status_cd
-voter_status_active: A
-voter_status_inactive: I
+voter_status_active:
+  - A
+voter_status_inactive:
+  - I
+# voter_status_temporary: S ?
+# another unknown voter status: D ?
 voter_status_cancelled: R
-voter_status_temporary: S
 not_registered_voter_status_set:
   - R
 reason_code: voter_status_reason_desc

--- a/reggie/configs/data/north_carolina.yaml
+++ b/reggie/configs/data/north_carolina.yaml
@@ -15,13 +15,13 @@ early_voter_identifier: absent_ind
 voter_status: status_cd
 voter_status_active:
   - A
+  - S   # TEMPORARY (APPLICABLE TO MILITARY AND OVERSEAS)
 voter_status_inactive:
   - I
-# voter_status_temporary: S ?
-# another unknown voter status: D ?
 voter_status_cancelled: R
 not_registered_voter_status_set:
-  - R
+  - R   # REMOVED
+  - D   # DENIED
 reason_code: voter_status_reason_desc
 democratic_party: DEM
 republican_party: REP

--- a/reggie/configs/data/ohio.yaml
+++ b/reggie/configs/data/ohio.yaml
@@ -11,8 +11,10 @@ primary_locale_identifier: COUNTY_NUMBER
 numeric_primary_locale: true
 birthday_identifier: DATE_OF_BIRTH
 voter_status: VOTER_STATUS
-voter_status_active: ACTIVE
-voter_status_inactive: CONFIRMATION
+voter_status_active:
+  - ACTIVE
+voter_status_inactive:
+  - CONFIRMATION
 democratic_party: D
 republican_party: R
 no_party_affiliation: 'NULL'

--- a/reggie/configs/data/oklahoma.yaml
+++ b/reggie/configs/data/oklahoma.yaml
@@ -20,8 +20,10 @@ party_identifier: PolitalAff
 birthday_identifier: DateOfBirth
 voter_id: VoterID
 voter_status: Status
-voter_status_active: A
-voter_status_inactive: I
+voter_status_active:
+  - A
+voter_status_inactive:
+  - I
 democratic_party: DEM
 republican_party: REP
 libertarian_party: LIB

--- a/reggie/configs/data/pennsylvania.yaml
+++ b/reggie/configs/data/pennsylvania.yaml
@@ -14,8 +14,10 @@ valid_voting_methods: ['AP', 'AB', 'P']
 absentee_ballot_code: AB
 provisional_ballot_code: P
 voter_status: voter_status
-voter_status_active: A
-voter_status_inactive: I
+voter_status_active:
+  - A
+voter_status_inactive:
+  - I
 # There is a very rarely used voter status: "D", is this denied?
 party_identifier: party_identifier
 democratic_party: D

--- a/reggie/configs/data/texas.yaml
+++ b/reggie/configs/data/texas.yaml
@@ -9,8 +9,10 @@ primary_locale_identifier: County_Code
 numeric_primary_locale: true
 birthday_identifier: Date_of_Birth
 voter_status: Status_Code
-voter_status_active: V
-voter_status_inactive: S
+voter_status_active:
+  - V
+voter_status_inactive:
+  - S
 voter_status_cancelled: C
 not_registered_voter_status_set:
   - C

--- a/reggie/configs/data/vermont.yaml
+++ b/reggie/configs/data/vermont.yaml
@@ -19,10 +19,12 @@ numeric_primary_locale: FALSE
 birthday_identifier: Year of Birth
 voter_id: VoterID
 voter_status: Status
-voter_status_active: ACTIVE
-voter_status_inactive: CHALLENGED
+voter_status_active:
+  - ACTIVE
+voter_status_inactive:
+  - CHALLENGED
 # Currently not used
-voter_status_waitlist: N18
+voter_status_preregistered: N18
 democratic_party: None
 republican_party: None
 no_party_affiliation: npa

--- a/reggie/configs/data/virginia.yaml
+++ b/reggie/configs/data/virginia.yaml
@@ -11,11 +11,12 @@ primary_locale_identifier: LOCALITYNAME
 numeric_primary_locale: false
 birthday_identifier: DOB
 voter_status: STATUS
-voter_status_active: Active
-voter_status_inactive: Inactive
-voter_status_incomplete: Incomplete
+voter_status_active:
+  - Active
+voter_status_inactive:
+  - Inactive
+# voter_status_incomplete: Incomplete ?
 voter_status_cancelled: Cancelled
-voter_status_denied: Denied
 not_registered_voter_status_set:
   - Cancelled
   - Denied

--- a/reggie/configs/data/virginia.yaml
+++ b/reggie/configs/data/virginia.yaml
@@ -15,11 +15,11 @@ voter_status_active:
   - Active
 voter_status_inactive:
   - Inactive
-# voter_status_incomplete: Incomplete ?
 voter_status_cancelled: Cancelled
 not_registered_voter_status_set:
   - Cancelled
   - Denied
+  - Incomplete  # guessing that these are denied for being incomplete, so not registered
 democratic_party: Democrat
 republican_party: Republican
 no_party_affiliation: 'NULL'

--- a/reggie/configs/data/washington.yaml
+++ b/reggie/configs/data/washington.yaml
@@ -19,8 +19,10 @@ party_identifier: party_identifier
 birthday_identifier: Birthdate
 voter_id: StateVoterID
 voter_status: StatusCode
-voter_status_active: A
-voter_status_inactive: I
+voter_status_active:
+  - A
+voter_status_inactive:
+  - I
 missing_required_fields: true
 demographic_fields_available:
   - age

--- a/reggie/configs/data/west_virginia.yaml
+++ b/reggie/configs/data/west_virginia.yaml
@@ -48,8 +48,10 @@ precinct_identifier: Precinct_Number
 
 # Voter status fields.  Only Active or Inactive
 voter_status: Status
-voter_status_active: active
-voter_status_inactive: inactive
+voter_status_active:
+  - active
+voter_status_inactive:
+  - inactive
 
 # Demographic fields
 birthday_identifier: DATE OF BIRTH

--- a/reggie/configs/data/wisconsin.yaml
+++ b/reggie/configs/data/wisconsin.yaml
@@ -20,8 +20,10 @@ primary_locale_type: jurisdiction
 birthday_identifier: DATE_OF_BIRTH
 early_voter_identifier: IsPermanentAbsentee
 voter_status: voter_status
-voter_status_active: Active
-voter_status_inactive: None
+voter_status_active:
+  - Active
+voter_status_inactive:
+  - None
 voter_status_cancelled: Inactive
 not_registered_voter_status_set:
   - Inactive


### PR DESCRIPTION
**Addresses issue(s): https://app.asana.com/0/1205510425969296/1206377591106496/f **

## What this does
Changes voter_status_active and voter_status_inactive into lists, to allow for the possibility of multiple values that denote the same status.

Standardizes the voter-status-related yaml keys to only allow: [voter_status_active, voter_status_inactive, voter_status_not_registered, voter_status_cancelled (a specific case of voter_status_not_registered), voter_status_preregistered], and removes all other extraneous keys. Leaves a comment if a status is not covered under any of these current cases.

Also re-classifies a couple of stray statuses based on conversations with analysts.

## Checklist
- [ ] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [x] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - [Inspector PR](https://github.com/Voteshield/Inspector/pull/1844)
