### PR TITLE
Add back some wayward statuses, for use in feature creation

### DIFF
--- a/reggie/configs/data/arizona.yaml
+++ b/reggie/configs/data/arizona.yaml
@@ -39,6 +39,7 @@ not_registered_voter_status_set:
   - 'N   ' # not eligible
   - 'NR  ' # not registered
 #  - 'S   ' # suspense
+voter_status_suspense: 'S   '
 # Clint: "It appears from media reports that 'suspense' in AZ is a 'not registered'.
 # They can't vote because the voter needs to provide more info to election officials."
 # But Clint thinks we should leave it in the file for now, until we find out more.

--- a/reggie/configs/data/arizona2.yaml
+++ b/reggie/configs/data/arizona2.yaml
@@ -28,6 +28,7 @@ not_registered_voter_status_set:
   - 'not eligible'
   - 'not registered'
 #  - suspense
+voter_status_suspense: suspense
 # Clint: "It appears from media reports that 'suspense' in AZ is a 'not registered'.
 # They can't vote because the voter needs to provide more info to election officials."
 # But Clint thinks we should leave it in the file for now, until we find out more.

--- a/reggie/configs/data/kansas.yaml
+++ b/reggie/configs/data/kansas.yaml
@@ -15,6 +15,7 @@ voter_status_active:
 voter_status_inactive:
   - I
 # There is an unknown voter status in the file: S
+voter_status_s: S
 democratic_party: Democratic
 republican_party: Republican
 libertarian_party: Libertarian

--- a/reggie/configs/data/pennsylvania.yaml
+++ b/reggie/configs/data/pennsylvania.yaml
@@ -19,6 +19,7 @@ voter_status_active:
 voter_status_inactive:
   - I
 # There is a very rarely used voter status: "D", is this denied?
+voter_status_d: D
 party_identifier: party_identifier
 democratic_party: D
 republican_party: R


### PR DESCRIPTION
**Addresses issue(s):  https://voteshield.sentry.io/issues/4961524340/ **

## What this does
I didn't realize that "voter_status_x" keys were also used for feature creation. Adding back the few statuses that don't fall under any umbrella, so we have a record of each status in the yamls.

## Checklist
- [ ] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **NO**
