### PR TITLE
Fix georgia locale codes and missing county name

### DIFF
--- a/reggie/ingestion/preprocessor/georgia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/georgia_preprocessor.py
@@ -205,7 +205,10 @@ class PreprocessGeorgia(Preprocessor):
             # Convert county back to numbers to match existing system
             county_dict = self.config.primary_locale_names[self.config.primary_locale_type]
             county_dict = {v.lower(): str(int(k)) for k, v in county_dict.items()}
+            # Sometimes GA drops the spaces in county names and sometimes they don't
             county_dict["dekalb"] = "44"
+            county_dict["benhill"] = "9"
+            county_dict["jeffdavis"] = "80"
             df_voters["County_code"] = df_voters["County_code"].str.lower().map(county_dict)
 
             # Convert voter status to match existing system
@@ -394,7 +397,7 @@ class PreprocessGeorgia(Preprocessor):
         )
 
         # Check the file for all the proper locales
-        df_voters["County_code"] = df_voters["County_code"].astype(str)
+        df_voters["County_code"] = df_voters["County_code"].astype(float).astype(int).astype(str)
         self.locale_check(
             set(df_voters[self.config["primary_locale_identifier"]]),
         )


### PR DESCRIPTION
**Addresses issue(s): https://voteshield.sentry.io/issues/4925968239 **

## What this does
Ensures Georgia locale codes will be integer strings. Ensures we do not drop counties with or without spaces in their names.

## Checklist
- [ ] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **NO**
