### PR TITLE
Force NY counties to be ints

### DIFF
--- a/reggie/ingestion/preprocessor/new_york_preprocessor.py
+++ b/reggie/ingestion/preprocessor/new_york_preprocessor.py
@@ -148,6 +148,18 @@ class PreprocessNewYork(Preprocessor):
         )
 
         # Check the file for all the proper locales
+        def locale_convert_str(x):
+            try:
+                if np.isnan(x):
+                    return x
+                else:
+                    return str(int(float(x)))
+            except:
+                return x
+
+        main_df[self.config["primary_locale_identifier"]] = main_df[
+            self.config["primary_locale_identifier"]
+        ].map(locale_convert_str)
         self.locale_check(
             set(main_df[self.config["primary_locale_identifier"]]),
         )


### PR DESCRIPTION
**Addresses issue(s): https://voteshield.sentry.io/issues/5106252842/?project=5552704 **

## What this does
Fixes the locale warning email in NY. New file contained null row, which forced locales to be floats in pandas. This reverts them to ints, so the local warning will not be triggered.

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **NO**
