### PR TITLE
Handle Michigan April 2024 history file

### DIFF
--- a/reggie/ingestion/preprocessor/michigan_preprocessor.py
+++ b/reggie/ingestion/preprocessor/michigan_preprocessor.py
@@ -184,14 +184,19 @@ class PreprocessMichigan(Preprocessor):
             if self.file_date > datetime(2024, 4, 8).date():
 
                 header = hist_file["obj"].readline().decode().strip().replace('"',"")
-                hdf = self.read_csv_count_error_lines(
-                    hist_file["obj"], header=None, na_filter=False, on_bad_lines="warn"
-                )
                 header = header.split(",")
 
-                # Drop final (empty) column if dataframe is too long for header
-                if len(header) < hdf.shape[1]:
-                    hdf.drop(columns=[hdf.columns[-1]], inplace=True)
+                # Read extra column, in case there are inconsistent commas
+                hdf = self.read_csv_count_error_lines(
+                    hist_file["obj"],
+                    header=None,
+                    na_filter=False,
+                    on_bad_lines="warn",
+                    names=range(len(header) + 1)
+                )
+
+                # Drop final (empty) column
+                hdf.drop(columns=[hdf.columns[-1]], inplace=True)
 
                 # Apply header
                 hdf.columns = header

--- a/reggie/ingestion/preprocessor/michigan_preprocessor.py
+++ b/reggie/ingestion/preprocessor/michigan_preprocessor.py
@@ -34,6 +34,7 @@ class PreprocessMichigan(Preprocessor):
         )
         self.raw_s3_file = raw_s3_file
         self.processed_file = None
+        self.file_date = parser.parse(force_date).date()
 
     def execute(self):
         if self.raw_s3_file is not None:
@@ -175,9 +176,31 @@ class PreprocessMichigan(Preprocessor):
                 na_filter=False,
             )
         elif hist_file["name"][-3:] == "csv":
-            hdf = self.read_csv_count_error_lines(
-                hist_file["obj"], na_filter=False, on_bad_lines="warn"
-            )
+
+            # April 2024 history file has an empty column at end
+            # (since they dropped a column), but one too few headers.
+            # So need to read header separately to get it to read
+            # in correctly.
+            if self.file_date > datetime(2024, 4, 8).date():
+
+                header = hist_file["obj"].readline().decode().strip().replace('"',"")
+                hdf = self.read_csv_count_error_lines(
+                    hist_file["obj"], header=None, na_filter=False, on_bad_lines="warn"
+                )
+                header = header.split(",")
+
+                # Drop final (empty) column if dataframe is too long for header
+                if len(header) < hdf.shape[1]:
+                    hdf.drop(columns=[hdf.columns[-1]], inplace=True)
+
+                # Apply header
+                hdf.columns = header
+
+            else:
+                hdf = self.read_csv_count_error_lines(
+                    hist_file["obj"], na_filter=False, on_bad_lines="warn"
+                )
+
             if ("IS_ABSENTEE_VOTER" not in hdf.columns) and (
                 "IS_PERMANENT_ABSENTEE_VOTER" in hdf.columns
             ):


### PR DESCRIPTION
**Addresses issue(s): https://app.asana.com/0/1205510425969296/1207197107650871/f **

## What this does
Michigan's most recent voting history file (April 2024) has an incorrect number of headers for the number of columns. (The final column is empty, but there are stray commas creating a phantom column, likely because they manually deleted the final data column.)

This adds code to make sure the history data is read correctly even if the headers are mismatched.

### Side effects
Hopefully none

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [x] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **NO**
