### PR TITLE
Handle NC registration dates that are 'XX-XX-XXXX'

### DIFF
--- a/reggie/ingestion/preprocessor/north_carolina_preprocessor.py
+++ b/reggie/ingestion/preprocessor/north_carolina_preprocessor.py
@@ -138,6 +138,14 @@ class PreprocessNorthCarolina(Preprocessor):
         del voter_groups, vote_hist, all_history, vote_type
         gc.collect()
 
+        # In May 2024, NC started using "XX-XX-XXXX" for
+        # registration dates of some cancelled and
+        # inactive voters. Need to convert these to
+        # explicitly null for our system.
+        voter_df["registr_dt"] = voter_df["registr_dt"].map(
+            lambda x: x if x != "XX-XX-XXXX" else ""
+        )
+
         voter_df = self.config.coerce_strings(voter_df)
         voter_df = self.config.coerce_dates(voter_df)
         voter_df = self.config.coerce_numeric(


### PR DESCRIPTION
**Addresses issue(s): https://voteshield.sentry.io/issues/5313813370 **

## What this does
Correct NC registration dates from string "XX-XX-XXXX" to null. NC has apparently started listing some registration dates (for mostly cancelled and inactive voters) as "XX-XX-XXXX".

### Side effects

<!-- Replace: Any other smaller issues or code cleanup that was done in this PR that wasn't really associated with the main goal of the PR -->

## Questions

<!-- Replace: If you have any open questions about this pull request; make sure to tag @people if needed -->

## How to test

<!-- Replace: Specifics on how to test that this pull request is working properly, outside automated tests -->

1. _[Run this function]_
2. _[Go this API endpoint]_

## Checklist

<!-- Check these off in the Pull Request interface. Use the notes section to explain why something doesn't apply -->

- [ ] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context

- Requires dependencies update: **YES/NO**
- This is directly related to a pull request in another repo? **YES/NO**
  - [Related pull request](https://github.com/Voteshield/REPO/pull/XXXXX) <!-- See https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests -->
