### PR TITLE
bugfix for missing header in new Washington history file

### DIFF
--- a/reggie/ingestion/preprocessor/washington_preprocessor.py
+++ b/reggie/ingestion/preprocessor/washington_preprocessor.py
@@ -75,9 +75,30 @@ class PreprocessWashington(Preprocessor):
             line = hist_file["obj"].readline().decode()
             delimiter = detect(line)
             hist_file["obj"].seek(0)
-            temp = pd.read_csv(
-                hist_file["obj"], sep=delimiter, encoding="latin-1", dtype=str
-            )
+
+            # The newest history file from the 2024-06-03 file
+            # is missing a header, so account for that here.
+            if "CountyCode" in line:
+                temp = pd.read_csv(
+                    hist_file["obj"], sep=delimiter, encoding="latin-1", dtype=str
+                )
+            else:
+                # If no header in first line, set header=None
+                temp = pd.read_csv(
+                    hist_file["obj"],
+                    sep=delimiter,
+                    encoding="latin-1",
+                    dtype=str,
+                    header=None,
+                )
+                # And add header manually
+                temp.columns = [
+                    "VoterHistoryID",
+                    "CountyCode",
+                    "CountyCode_Voting",
+                    "StateVoterID",
+                    "ElectionDate",
+                ]
             # There's a weird corruption of the county column name
             # in the 2021-2022 history file, so fix that:
             for c in temp.columns:


### PR DESCRIPTION
**Addresses issue(s): https://voteshield.sentry.io/issues/5450133600/ **

## What this does
Reads without header and adds header manually, because new Washington history file is missing header.

## Checklist
- [ ] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **NO**
