### PR TITLE
Add back recently removed columns from Virginia vote history

### DIFF
--- a/reggie/ingestion/preprocessor/virginia_preprocessor.py
+++ b/reggie/ingestion/preprocessor/virginia_preprocessor.py
@@ -82,6 +82,11 @@ class PreprocessVirginia(Preprocessor):
             + hist_df["ELECTION_DATE"]
         )
 
+        # 2024-06-04 file removed VOTE_IN_PERSON and PROTECTED from history file
+        for col in ["VOTE_IN_PERSON", "PROTECTED"]:
+            if col not in hist_df.columns:
+                hist_df[col] = False
+
         # Gathers the votetype columns that are initially boolean and replaces them with the word version of their name
         # collect all the columns where the value is True, combine to one votetype history separated by underscores
         # parsing in features will pull out the appropriate string


### PR DESCRIPTION
**Addresses issue(s): <!-- Add Issue number here, e.g. "Resolves #1001" or "Resolves Voteshield/reggie#101" -->**

## What this does
Virginia recently removed VOTE_IN_PERSON and PROTECTED from it's history file. This replaces the missing columns with all False values.

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **NO**
