### PR TITLE
Fix read of first chunk of first file in Iowa

### DIFF
--- a/reggie/ingestion/preprocessor/iowa_preprocessor.py
+++ b/reggie/ingestion/preprocessor/iowa_preprocessor.py
@@ -75,6 +75,8 @@ class PreprocessIowa(Preprocessor):
 
         # Reads the headers in on the first file given
         headers = pd.read_csv(first_file["obj"], nrows=1).columns
+        # reset pointer for next read
+        first_file["obj"].seek(0)
 
         # Gather the columns for renaming in order to fit the original schema in the database and then rename
         # so that the columns in the header will fit what is expected


### PR DESCRIPTION
**Addresses issue(s): missing voters issue raised by Clint **

## What this does
Fixes a long-standing problem in Iowa where we were skipping a small chunk of voters at the beginning of whichever file is deemed the "first file" (from which the header is read).

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **NO**
