### PR TITLE
Add capital versions of Georgia race key (they just changed them again)

### DIFF
--- a/reggie/configs/data/georgia.yaml
+++ b/reggie/configs/data/georgia.yaml
@@ -393,6 +393,14 @@ race_options:
   American Indian: american_indian
   Refused: refused
   Multi-Racial: multi_racial
+  WHITE: white
+  BLACK: black
+  HISPANIC/LATINO: hispanic_or_latino
+  ASIAN/PACIFIC ISLANDER: asian_or_pacific_islander
+  AMERICAN INDIAN: american_indian
+  ALASKAN NATIVE: alaskan_native
+  OTHER: other
+  UNKNOWN: unknown
 
 # 2023 column header update
 # new column name: original column name


### PR DESCRIPTION
**Addresses issue(s): raised by Sara **

## What this does
Adds the current versions of Georgia race codes into the yaml.

## Checklist
- [ ] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **NO**
