### PR TITLE
Bugfix handling of new Arizona history columns (changed Sept 2024)

### DIFF
--- a/reggie/configs/data/arizona2.yaml
+++ b/reggie/configs/data/arizona2.yaml
@@ -193,3 +193,13 @@ ordered_generated_columns:
   - sparse_history
   - votetype_history
   - party_history
+# Arizona stopped using full election dates in Sept 2024,
+# but we can add back the ones we know about.
+# (Although it will be annoying to maintain this list.)
+election_dates:
+  GENERAL2020: 11/03/2020
+  PRIMARY2022: 08/02/2022
+  GENERAL2022: 11/08/2022
+  2024PRESIDENTIALPREFERENCE: 03/19/2024
+  PRIMARY2024: 07/30/2024
+  GENERAL2024: 11/05/2024

--- a/reggie/ingestion/preprocessor/arizona2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/arizona2_preprocessor.py
@@ -151,7 +151,7 @@ class PreprocessArizona2(Preprocessor):
         sorted_codes_dict = {
             k: {
                 "index": int(i),
-                "count": int(counts[i]),
+                "count": int(counts[k]),
                 "date": handle_history_dates(k),
             }
             for i, k in enumerate(sorted_codes)

--- a/reggie/ingestion/preprocessor/arizona2_preprocessor.py
+++ b/reggie/ingestion/preprocessor/arizona2_preprocessor.py
@@ -6,12 +6,20 @@ from io import StringIO
 
 import numpy as np
 import pandas as pd
+import re
 
 from reggie.ingestion.download import (
     Preprocessor,
     date_from_str,
     FileItem,
 )
+
+
+HISTORY_COLUMN_REGEX = re.compile(
+    "^(\d|GENERAL|PRIMARY|PRESIDENTIAL)",
+    flags=re.I,
+)
+YEAR_REGEX = re.compile("\d{4}")
 
 
 class PreprocessArizona2(Preprocessor):
@@ -95,8 +103,9 @@ class PreprocessArizona2(Preprocessor):
         # Starting in Feb 2024 occupation was removed from the columns they send us
         if "Occupation" not in main_df.columns:
             main_df["Occupation"] = np.nan
-        voter_columns = [c for c in main_df.columns if not c[0].isdigit()]
-        history_columns = [c for c in main_df.columns if c[0].isdigit()]
+
+        voter_columns = [c for c in main_df.columns if not HISTORY_COLUMN_REGEX.match(c)]
+        history_columns = [c for c in main_df.columns if HISTORY_COLUMN_REGEX.match(c)]
 
         self.column_check(voter_columns)
         to_normalize = history_columns + [
@@ -118,6 +127,22 @@ class PreprocessArizona2(Preprocessor):
             else x
         )
 
+        # AZ removed full history dates from column names in
+        # Sept 2024, so have to handle a little more manually now.
+        def handle_history_dates(col_name):
+            # Try original method, which works if full dates
+            d = date_from_str(col_name)
+            if d is not None:
+                return d
+            # Try manual matching to known elections
+            if col_name in self.config["election_dates"]:
+                return self.config["election_dates"][col_name]
+            # Default placeholder otherwise is just Jan 1
+            d = YEAR_REGEX.search(col_name)
+            if d is not None:
+                return f"01/01/{d.group(0)}"
+            return None
+
         # handle history:
         sorted_codes = history_columns[::-1]
         hist_df = main_df[sorted_codes]
@@ -127,7 +152,7 @@ class PreprocessArizona2(Preprocessor):
             k: {
                 "index": int(i),
                 "count": int(counts[i]),
-                "date": date_from_str(k),
+                "date": handle_history_dates(k),
             }
             for i, k in enumerate(sorted_codes)
         }


### PR DESCRIPTION
**Addresses issue(s): bug found accidentally in logs **

## What this does
Handles the new format of history columns in Arizona, which unfortunately no longer fully include the election date. So some dates have been added manually to make current data more usable, but this will be hard to maintain unfortunately.

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [x] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - [Update reggie with handling of new Arizona history columns (changed Sept 2024)](https://github.com/Voteshield/Inspector/pull/1996)
