### PR TITLE
NC apparently switched what obfuscated registration dates look like

### DIFF
--- a/reggie/ingestion/preprocessor/north_carolina_preprocessor.py
+++ b/reggie/ingestion/preprocessor/north_carolina_preprocessor.py
@@ -142,8 +142,9 @@ class PreprocessNorthCarolina(Preprocessor):
         # registration dates of some cancelled and
         # inactive voters. Need to convert these to
         # explicitly null for our system.
+        # In Oct 2024, they switched to these to "##/##/####".
         voter_df["registr_dt"] = voter_df["registr_dt"].map(
-            lambda x: x if x != "XX-XX-XXXX" else ""
+            lambda x: x if (("X" not in x) and ("#" not in x)) else ""
         )
 
         voter_df = self.config.coerce_strings(voter_df)


### PR DESCRIPTION
**Addresses issue(s):  https://voteshield.sentry.io/issues/5313813370 **

## What this does
Handles both old "XX-XX-XXXX" and new "##/##/####" obfuscated registration dates in North Carolina.

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - TBD
