### PR TITLE
Feature - removal groups with voters at same address

### DIFF
--- a/reggie/configs/data/pennsylvania.yaml
+++ b/reggie/configs/data/pennsylvania.yaml
@@ -62,6 +62,11 @@ address_fields:
   - mail_zip
   - county
   - mail_country
+street_address_fields:
+  - house_number
+  - house_number_suffix
+  - street_name
+  - city
 format:
   separate_hist: false
   segmented_files: true


### PR DESCRIPTION
**Addresses issue(s): https://app.asana.com/0/1205510425969296/1207554750066685/f **

## What this does
Specifies the set of address fields that will be used for the new "same address" feature in each state. This is needed because (as I learned in the state data research project), states split up street address (3 Main St) and apartment (2B) in maybe different ways and different fields. Since we want this feature to capture street address only and not apartment number, the best way to do this is probably to manually specify fields for each state.

NOTE: I still need to add other states to the PR, but putting this up for initial review for the moment.

## Checklist
- [ ] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - [Inspector](tbd)
  - [frontend](tbd)
