### PR TITLE
Virginia - Add year-only date format for changed DOB

### DIFF
--- a/reggie/configs/data/virginia.yaml
+++ b/reggie/configs/data/virginia.yaml
@@ -34,7 +34,9 @@ absentee_ballot_code: absentee
 vote_in_person_ballot_code: inPerson
 protected_ballot_code: protected
 provisional_ballot_code: provisional
-date_format: '%m/%d/%Y'
+date_format:
+  - '%m/%d/%Y'
+  - "%Y"
 generated_columns:
   all_history: text[]
   sparse_history: int[]


### PR DESCRIPTION
**Addresses issue(s): https://app.asana.com/0/1205510425969296/1208581795339592/f **

## What this does
Fix birth dates in new Virginia files (they switched to birth year only).

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - [Inspector PR](https://github.com/Voteshield/Inspector/pull/2004)
