### PR TITLE
Kansas decided (?) to scramble their header yesterday

### DIFF
--- a/reggie/ingestion/preprocessor/kansas_preprocessor.py
+++ b/reggie/ingestion/preprocessor/kansas_preprocessor.py
@@ -70,7 +70,7 @@ class PreprocessKansas(Preprocessor):
                 if df.columns[0] != self.config["ordered_columns_new"][0]:
                     # Assume they are scrambled but still the same columns;
                     # Rearrange order.
-                    df = df[c["ordered_columns_new"]]
+                    df = df[self.config["ordered_columns_new"]]
 
             else:
                 logging.info("Incorrect number of columns found for Kansas")

--- a/reggie/ingestion/preprocessor/kansas_preprocessor.py
+++ b/reggie/ingestion/preprocessor/kansas_preprocessor.py
@@ -58,12 +58,21 @@ class PreprocessKansas(Preprocessor):
                     on_bad_lines="warn",
                     encoding="latin-1",
                 )
+
         try:
             df.columns = self.config["ordered_columns"]
         except ValueError:
-            try:
-                df.columns = self.config["ordered_columns_new"]
-            except ValueError:
+            if len(df.columns) == len(self.config["ordered_columns_new"]):
+
+                # In Nov 2024, Kansas scrambled the column order,
+                # although the columns are still the same set
+                # as "ordered_columns_new".
+                if df.columns[0] != self.config["ordered_columns_new"][0]:
+                    # Assume they are scrambled but still the same columns;
+                    # Rearrange order.
+                    df = df[c["ordered_columns_new"]]
+
+            else:
                 logging.info("Incorrect number of columns found for Kansas")
                 raise MissingNumColumnsError(
                     "{} state is missing columns".format(self.state),


### PR DESCRIPTION
**Addresses issue(s): https://voteshield.sentry.io/issues/5560588460/?project=5552704&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=0 **

## What this does
Allows scrambled header to get rearranged and process file normally.

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **YES**
  - Inspector TBD
