### PR TITLE
Michigan permanent absentee column changed name

### DIFF
--- a/reggie/ingestion/preprocessor/michigan_preprocessor.py
+++ b/reggie/ingestion/preprocessor/michigan_preprocessor.py
@@ -154,6 +154,16 @@ class PreprocessMichigan(Preprocessor):
                 inplace=True,
             )
 
+        # Sometime after July 2024, Michigan removed
+        # "IS_PERMANENT_ABSENTEE_VOTER" from the voter file.
+        # It was eventually replaced by "IS_PERM_AV_BALLOT_VOTER"
+        # but it may be missing from some files in the interim.
+        if "IS_PERM_AV_BALLOT_VOTER" in vdf.columns:
+            vdf.rename(
+                columns={"IS_PERM_AV_BALLOT_VOTER": "IS_PERMANENT_ABSENTEE_VOTER"},
+                inplace=True,
+            )
+
         vdf = self.reconcile_columns(vdf, self.config["columns"])
         vdf = fill_empty_columns(vdf)
         vdf = vdf.reindex(columns=self.config["ordered_columns"])


### PR DESCRIPTION
## What this does
Over the summer, we were told that Michigan was removing the IS_PERMANENT_ABSENTEE_VOTER data. But at some point it reappered as IS_PERM_AV_BALLOT_VOTER. Changing back to the original name so we can continue to see it.

### Side effects

<!-- Replace: Any other smaller issues or code cleanup that was done in this PR that wasn't really associated with the main goal of the PR -->

## Questions

<!-- Replace: If you have any open questions about this pull request; make sure to tag @people if needed -->

## How to test

<!-- Replace: Specifics on how to test that this pull request is working properly, outside automated tests -->

1. _[Run this function]_
2. _[Go this API endpoint]_

## Checklist

<!-- Check these off in the Pull Request interface. Use the notes section to explain why something doesn't apply -->

- [ ] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context

- Requires dependencies update: **YES/NO**
- This is directly related to a pull request in another repo? **YES/NO**
  - [Related pull request](https://github.com/Voteshield/REPO/pull/XXXXX) <!-- See https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests -->
