### PR TITLE
Bugfix locale check

### DIFF
--- a/reggie/ingestion/download.py
+++ b/reggie/ingestion/download.py
@@ -690,6 +690,9 @@ class Preprocessor:
         :param locale_set: a set of locale names derived from the snapshot
         :raises MissingLocaleError:
         """
+        # Prevent floats from being compared, in states with numeric locales
+        locale_set = {int(x) if type(x) == float else x for x in locale_set}
+
         # Convert locale_set items to strings
         locale_set = {
             str(item) if not isinstance(item, str) else item
@@ -715,9 +718,11 @@ class Preprocessor:
             if locale_diff:
                 raise MissingLocaleError(
                     f"{self.state} is missing expected locales: "
-                    f"{', '.join(locale_diff)}",
+                    f"{', '.join(locale_diff)}. "
+                    f"Instead, the file contains these locales: "
+                    f"{', '.join(locale_set - expected_locales)}. ",
                     self.state,
-                    locale_diff
+                    locale_diff,
                 )
         except MissingLocaleError as mle:
             # Save the error for future reference


### PR DESCRIPTION
**Addresses issue(s): repeating issue of locale check sometimes spuriously failing **

## What this does
Bugfix case where a null locale has forced locales to be floats, which then don't match with the ints in the official list. Improve error output for better debugging in other potential mismatch cases.

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **NO**
- This is directly related to a pull request in another repo? **NO**
