### PR TITLE
Fix for April 2026 florida file with 2 extra useless folders

### DIFF
--- a/reggie/ingestion/preprocessor/florida_preprocessor.py
+++ b/reggie/ingestion/preprocessor/florida_preprocessor.py
@@ -46,6 +46,16 @@ class PreprocessFlorida(Preprocessor):
         del self.main_file, self.temp_files
         gc.collect()
 
+        # In 2026-04-14 file, Florida added 2 apparently useless
+        # folders full of extra county text files
+        # (details are in the state-by-state processing doc.)
+        # I am filtering out the files in these folders entirely.
+        new_files = [
+            f for f in new_files
+            if ("verificationfiles" not in f["name"].lower())
+            and ("processedfiles" not in f["name"].lower())
+        ]
+
         vote_history_files = []
         voter_files = []
         for i in new_files:


### PR DESCRIPTION
**Addresses issue(s): <!-- Add Issue number here, e.g. "Resolves #1001" or "Resolves Voteshield/reggie#101" -->**

## What this does
Removes 2 useless folders during Florida file collection.


## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **YES/NO**
- This is directly related to a pull request in another repo? **YES/NO**
  - [Related pull request](https://github.com/Voteshield/REPO/pull/XXXXX) <!-- See https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests -->
