### PR TITLE
Bugfix - add eligibility file class to allow lookups in s3

### DIFF
--- a/reggie/ingestion/utils.py
+++ b/reggie/ingestion/utils.py
@@ -158,7 +158,11 @@ def get_s3_uploads(state, file_class, source, s3_bucket, testing=False):
     assert(file_class in [PROCESSED_FILE_PREFIX, RAW_FILE_PREFIX, MODIFICATION_FILE_PREFIX,
                           META_FILE_PREFIX, ELIGIBILITY_FILE_PREFIX])
     if not testing:
-        prefix = "{}/{}/{}".format(file_class, state, source)
+        # eligibility parquet files don't include source in prefix
+        if file_class == ELIGIBILITY_FILE_PREFIX:
+            prefix = f"{file_class}/{state}"
+        else:
+            prefix = "{}/{}/{}".format(file_class, state, source)
     else:
         prefix = "testing/{}/{}/".format(file_class, state)
     keys = [a for a in s3.Bucket(s3_bucket).objects.filter(Prefix=prefix)

--- a/reggie/ingestion/utils.py
+++ b/reggie/ingestion/utils.py
@@ -8,7 +8,8 @@ from botocore.exceptions import ClientError
 
 from reggie.configs.configs import Config
 from reggie.reggie_constants import META_FILE_PREFIX, NULL_CHAR, \
-    PROCESSED_FILE_PREFIX, RAW_FILE_PREFIX, MODIFICATION_FILE_PREFIX
+    PROCESSED_FILE_PREFIX, RAW_FILE_PREFIX, MODIFICATION_FILE_PREFIX, \
+    ELIGIBILITY_FILE_PREFIX
 
 s3 = boto3.resource("s3")
 
@@ -155,7 +156,7 @@ def get_s3_uploads(state, file_class, source, s3_bucket, testing=False):
     :return:
     """
     assert(file_class in [PROCESSED_FILE_PREFIX, RAW_FILE_PREFIX, MODIFICATION_FILE_PREFIX,
-                          META_FILE_PREFIX])
+                          META_FILE_PREFIX, ELIGIBILITY_FILE_PREFIX])
     if not testing:
         prefix = "{}/{}/{}".format(file_class, state, source)
     else:

--- a/reggie/reggie_constants.py
+++ b/reggie/reggie_constants.py
@@ -24,6 +24,7 @@ CONFIG_CHUNK_URLS = "data_chunk_links"
 RAW_FILE_PREFIX = "raw_voter_file"
 PROCESSED_FILE_PREFIX = "voter_file"
 MODIFICATION_FILE_PREFIX = "modification_file"
+ELIGIBILITY_FILE_PREFIX = "removal_eligibility"
 
 META_FILE_PREFIX = "meta"
 NULL_CHAR = "n"


### PR DESCRIPTION
## What this does
Updates s3 utility function to include newer eligibility file class.

## Checklist
- [x] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [x] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context

- Requires dependencies update: **YES/NO**
- This is directly related to a pull request in another repo? **YES/NO**
  - [Related pull request](https://github.com/Voteshield/REPO/pull/XXXXX) <!-- See https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests -->
