### PR TITLE
Attempt to align changed Texas data columns

### DIFF
--- a/reggie/configs/data/texas.yaml
+++ b/reggie/configs/data/texas.yaml
@@ -521,3 +521,18 @@ column_aliases:
     cd_status: Status_Code
     dt_effective_registration: Effective_Date_of_Registration
     hispanic_surname: Hispanic_Surname_Flag
+    # Yet another set of column renames, Aug 2026
+    tx_street_number: Permanent_House_Number
+    tx_designator: Permanent_Designator
+    pre_direction: Permanent_Directional_Prefix
+    street_name: Permanent_Street_Name
+    street_type: Permanent_Street_Type
+    post_direction: Permanent_Directional_Suffix
+    cd_unit_type: Permanent_Unit_Type
+    tx_unit: Permanent_Unit_Number
+    ad_city: Permanent_City
+    tx_zip5: Permanent_Zipcode
+    mail_street_name: Mailing_Address_1
+    mail_ad_city: Mailing_City
+    mail_cd_state: Mailing_State
+    mail_ad_zip5: Mailing_Zipcode

--- a/reggie/ingestion/preprocessor/texas_preprocessor.py
+++ b/reggie/ingestion/preprocessor/texas_preprocessor.py
@@ -219,15 +219,19 @@ class PreprocessTexas(Preprocessor):
             if df_hist.empty:
                 df_hist = pd.DataFrame(columns=self.config["hist_columns"])
 
-            # Convert single address string back to multiple fields
-            parsed_addresses = df_voter["residential_address"].map(
-                self.parse_and_map_address
-            )
-            df_voter = pd.concat(
-                [df_voter, pd.DataFrame(parsed_addresses.tolist())],
-                axis=1,
-            )
-            df_voter.drop(columns=["residential_address"], inplace=True)
+            df_voter.columns = df_voter.columns.str.lower()
+
+            # Convert single address string back to multiple fields,
+            # in files that have combined "residential_address"
+            if "residential_address" in df_voter.columns:
+                parsed_addresses = df_voter["residential_address"].map(
+                    self.parse_and_map_address
+                )
+                df_voter = pd.concat(
+                    [df_voter, pd.DataFrame(parsed_addresses.tolist())],
+                    axis=1,
+                )
+                df_voter.drop(columns=["residential_address"], inplace=True)
 
             # New files from 2025 Dec and forward sometimes drop
             # hispanic_surname_flag entirely or use alternative
@@ -255,6 +259,11 @@ class PreprocessTexas(Preprocessor):
                     inplace=True,
                 )
 
+            # In Aug 2026 file, seems to be some systematic extra
+            # internal space in the column "mail_street_name"
+            if "mail_street_name" in df_voter.columns:
+                df["mail_street_name"] = df["mail_street_name"].str.split().str.join(" ")
+
             # Rename other columns back to old names
             df_voter.rename(
                 columns=self.config["column_aliases"],
@@ -272,7 +281,8 @@ class PreprocessTexas(Preprocessor):
                 "Mailing_State",
                 "Mailing_Zipcode",
             ]:
-                df_voter[col] = np.nan
+                if col not in df_voter.columns:
+                    df_voter[col] = np.nan
 
             # Make sure precinct is int, to match existing data
             def int_precincts(x):


### PR DESCRIPTION
**Addresses issue(s): https://voteshield.sentry.io/issues/7587685604/?project=5552704&query=is%3Aunresolved&referrer=issue-stream **

## What this does
Changes new Texas column names back to what they should be. Some other light address data normalization, to hopefully reduce spurious diffs. But, they have changed how addresses are split up in the source data again, so there's probably going to be a lot of spurious address diffs in any case, unfortunately.

## Checklist
- [ ] This has been tested locally.
  - Notes: <!-- Note if not performed -->
- [ ] [Commented code](https://docs.google.com/document/d/1M_i2i3V2aNq6Yiofwj5Su8mKGLs1ooQOJGHR-37WZzs/edit) in a way that is useful for others.
  - Notes: <!-- Note if not performed -->
- [ ] Updated or created relevant documentation.
  - Notes: <!-- Note if not performed -->
- [ ] Added automated tests relevant to this new code.
  - Notes: <!-- Note if not performed -->

## Other context
- Requires dependencies update: **YES/NO**
- This is directly related to a pull request in another repo? **YES/NO**
  - [Related pull request](https://github.com/Voteshield/REPO/pull/XXXXX) <!-- See https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests -->
